### PR TITLE
fix stack overflow and enable middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,14 +108,13 @@ func main() {
 	addr := fmt.Sprintf(":%d", *port)
 	metricsAddr := fmt.Sprintf(":%d", *metricsPort)
 	mux := http.NewServeMux()
-	mux.HandleFunc("/mutate", mod.Handle)
 
 	baseHandler := handler.Apply(
-		mux,
+		http.HandlerFunc(mod.Handle),
 		handler.InstrumentRoute(),
 		handler.Logging(),
 	)
-	mux.Handle("/", baseHandler)
+	mux.Handle("/mutate", baseHandler)
 
 	metricsMux := http.NewServeMux()
 	metricsMux.Handle("/metrics", promhttp.Handler())


### PR DESCRIPTION
*Issue #, if available:* #15 

*Description of changes:*
This makes two changes:
1. Enables the middleware on the /mutate endpoint.
2. Fixes the initial middleware setup that resulted in a recursive loop as there was no handler for `/` except the middleware itself.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
