### PR TITLE
Making changes for finding the oidc discovery endpoint in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This webhook is for mutating pods that will require AWS IAM access.
 1. [Create an OIDC provider][1] in IAM for your cluster. You can find the OIDC
    discovery endpoint by describing your EKS cluster.
     ```bash
-    aws eks describe-cluster --name $CLUSTER_NAME --query cluster.tokenDiscoveryEndpoint
+    aws eks describe-cluster --name $CLUSTER_NAME --query cluster.identity.oidc
     ```
     And enter "sts.amazonaws.com" as the client-id
 2. Create an IAM role for your pods and [modify the trust policy][2] to allow


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The command to find the oidc endpoint is incorrect in the README.md doc today 

```
1. 

bash-5.0$ aws eks describe-cluster --name $CLUSTER_NAME --query cluster.tokenDiscoveryEndpoint
null
bash-5.0$



2. 
bash-5.0$ aws eks describe-cluster --name $CLUSTER_NAME --query cluster.identity.oidc
{
    "issuer": "https://oidc.eks.us-west-2.amazonaws.com/id/ABCD"
}
bash-5.0$


```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
