### PR TITLE
Ensure AWS_WEB_IDENTITY_TOKEN_FILE points to correct path on windows pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ This webhook is for mutating pods that will require AWS IAM access.
               expirationSeconds: 86400
               path: token
     ```
+   
+### Usage with Windows container workloads
+
+To ensure workloads are scheduled on windows nodes have the right environment variables, they must have a `nodeSelector` targeting windows it must run on.  Workloads targeting windows nodes using `nodeAffinity` are currently not supported.
+```yaml
+  nodeSelector:
+    beta.kubernetes.io/os: windows
+```
+
+Or for Kubernetes 1.14+
+
+```yaml
+  nodeSelector:
+    kubernetes.io/os: windows
+```
+
+
 
 [1]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html
 [2]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html


### PR DESCRIPTION
**Issue #:** AWS Support Case ID `6708626561`

**Description of changes:**
If the pod is a windows container (identified by the `nodeSelector` `beta.kubernetes.io/os`), the path to the identity file is modified to be a valid windows path.

**Example:** `C:\var\run\secrets\eks.amazonaws.com\serviceaccount\token` is used instead of `/var/run/secrets/eks.amazonaws.com/serviceaccount/token`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
