### PR TITLE
Inject AWS_DEFAULT_REGION in mutated pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ This webhook is for mutating pods that will require AWS IAM access.
         image: container-image:version
     ### Everything below is added by the webhook ###
         env:
+        - name: AWS_DEFAULT_REGION
+          value: us-west-2
         - name: AWS_ROLE_ARN
           value: "arn:aws:iam::111122223333:role/s3-reader"
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
@@ -106,6 +108,7 @@ Or for Kubernetes 1.14+
 Usage of amazon-eks-pod-identity-webhook:
       --alsologtostderr                  log to standard error as well as files
       --annotation-prefix string         The Service Account annotation to look for (default "eks.amazonaws.com")
+      --aws-default-region string        If set, AWS_DEFAULT_REGION will be set to this value in mutated containers
       --in-cluster                       Use in-cluster authentication and certificate request API (default true)
       --kube-api string                  (out-of-cluster) The url to the API server
       --kubeconfig string                (out-of-cluster) Absolute path to the API server kubeconfig file
@@ -130,6 +133,11 @@ Usage of amazon-eks-pod-identity-webhook:
       --version                          Display the version and exit
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```
+
+### AWS_DEFAULT_REGION Injection
+
+When the `aws-default-region` flag is set this webhook will inject `AWS_DEFAULT_REGION` in mutated containers if `AWS_DEFAULT_REGION` and `AWS_REGION` are not already set.
+
 
 ## Installation
 

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 	audience := flag.String("token-audience", "sts.amazonaws.com", "The default audience for tokens. Can be overridden by annotation")
 	mountPath := flag.String("token-mount-path", "/var/run/secrets/eks.amazonaws.com/serviceaccount", "The path to mount tokens")
 	tokenExpiration := flag.Int64("token-expiration", 86400, "The token expiration")
+	region := flag.String("aws-default-region", "", "If set, AWS_DEFAULT_REGION will be set to this value in mutated containers")
 
 	version := flag.Bool("version", false, "Display the version and exit")
 
@@ -103,6 +104,7 @@ func main() {
 		handler.WithExpiration(*tokenExpiration),
 		handler.WithMountPath(*mountPath),
 		handler.WithServiceAccountCache(saCache),
+		handler.WithRegion(*region),
 	)
 
 	addr := fmt.Sprintf(":%d", *port)

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -179,28 +179,7 @@ var rawWindowsPodWithVolume = []byte(`
 }
 `)
 
-func getValidReview(isVolumePresent bool, isWindows bool, betaNodeSelector bool) *v1beta1.AdmissionReview {
-	var pod []byte
-	if isWindows {
-		if betaNodeSelector {
-			pod = rawWindowsBetaPodWithoutVolume
-		} else {
-			pod = rawWindowsPodWithoutVolume
-		}
-		if isVolumePresent {
-			if betaNodeSelector {
-				pod = rawWindowsBetaPodWithVolume
-			} else {
-				pod = rawWindowsPodWithVolume
-			}
-		}
-	} else {
-		pod = rawPodWithoutVolume
-		if isVolumePresent {
-			pod = rawPodWithVolume
-		}
-	}
-
+func getValidReview(pod []byte) *v1beta1.AdmissionReview {
 	return &v1beta1.AdmissionReview{
 		Request: &v1beta1.AdmissionRequest{
 			UID: "918ef1dc-928f-4525-99ef-988389f263c3",
@@ -289,37 +268,37 @@ func TestSecretStore(t *testing.T) {
 		{
 			"ValidRequestSuccessWithoutVolumes",
 			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
-			getValidReview(false, false, false),
+			getValidReview(rawPodWithoutVolume),
 			validResponseIfNoVolumesPresent,
 		},
 		{
 			"ValidRequestSuccessWindowsWithoutVolumes",
 			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
-			getValidReview(false, true, false),
+			getValidReview(rawWindowsBetaPodWithoutVolume),
 			validResponseIfWindowsNoVolumesPresent,
 		},
 		{
 			"ValidRequestSuccessWindowsBetaWithoutVolumes",
 			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
-			getValidReview(false, true, true),
+			getValidReview(rawWindowsBetaPodWithoutVolume),
 			validResponseIfWindowsNoVolumesPresent,
 		},
 		{
 			"ValidRequestSuccessWithVolumes",
 			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
-			getValidReview(true, false, false),
+			getValidReview(rawPodWithVolume),
 			validResponseIfVolumesPresent,
 		},
 		{
 			"ValidRequestSuccessWindowsWithVolumes",
 			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
-			getValidReview(true, true, false),
+			getValidReview(rawWindowsPodWithVolume),
 			validResponseIfWindowsVolumesPresent,
 		},
 		{
 			"ValidRequestSuccessWindowsBetaWithVolumes",
 			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
-			getValidReview(true, true, true),
+			getValidReview(rawWindowsBetaPodWithVolume),
 			validResponseIfWindowsVolumesPresent,
 		},
 	}

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -179,6 +179,72 @@ var rawWindowsPodWithVolume = []byte(`
 }
 `)
 
+var rawPodWithoutRegion = []byte(`
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "balajilovesoreos",
+	"uid": "be8695c4-4ad0-4038-8786-c508853aa255"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"image": "amazonlinux",
+		"name": "balajilovesoreos"
+	  }
+	],
+	"serviceAccountName": "default"
+  }
+}
+`)
+
+var rawPodWithAWSRegion = []byte(`
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "balajilovesoreos",
+	"uid": "be8695c4-4ad0-4038-8786-c508853aa255"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"image": "amazonlinux",
+		"name": "balajilovesoreos",
+		"env": [
+		  {"name":"AWS_REGION","value":"paris"}
+		]
+	  }
+	],
+	"serviceAccountName": "default"
+  }
+}
+`)
+
+var rawPodWithAWSDefaultRegion = []byte(`
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "balajilovesoreos",
+	"uid": "be8695c4-4ad0-4038-8786-c508853aa255"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"image": "amazonlinux",
+		"name": "balajilovesoreos",
+		"env": [
+		  {"name":"AWS_DEFAULT_REGION","value":"paris"}
+		]
+	  }
+	],
+	"serviceAccountName": "default"
+  }
+}
+`)
+
 func getValidReview(pod []byte) *v1beta1.AdmissionReview {
 	return &v1beta1.AdmissionReview{
 		Request: &v1beta1.AdmissionRequest{
@@ -209,6 +275,10 @@ var validPatchIfVolumesPresent = []byte(`[{"op":"add","path":"/spec/volumes/0","
 var validPatchIfWindowsNoVolumesPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"C:\\var\\run\\secrets\\eks.amazonaws.com\\serviceaccount\\token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 var validPatchIfWindowsVolumesPresent = []byte(`[{"op":"add","path":"/spec/volumes/0","value":{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"C:\\var\\run\\secrets\\eks.amazonaws.com\\serviceaccount\\token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 
+var validPatchIfNoRegionPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"seattle"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
+var validPatchIfRegionPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_REGION","value":"paris"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
+var validPatchIfDefaultRegionPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"paris"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
+
 var jsonPatchType = v1beta1.PatchType("JSONPatch")
 
 var validResponseIfNoVolumesPresent = &v1beta1.AdmissionResponse{
@@ -236,6 +306,27 @@ var validResponseIfWindowsVolumesPresent = &v1beta1.AdmissionResponse{
 	UID:       "",
 	Allowed:   true,
 	Patch:     validPatchIfWindowsVolumesPresent,
+	PatchType: &jsonPatchType,
+}
+
+var validResponseIfNoRegionPresent = &v1beta1.AdmissionResponse{
+	UID:       "",
+	Allowed:   true,
+	Patch:     validPatchIfNoRegionPresent,
+	PatchType: &jsonPatchType,
+}
+
+var validResponseIfRegionPresent = &v1beta1.AdmissionResponse{
+	UID:       "",
+	Allowed:   true,
+	Patch:     validPatchIfRegionPresent,
+	PatchType: &jsonPatchType,
+}
+
+var validResponseIfDefaultRegionPresent = &v1beta1.AdmissionResponse{
+	UID:       "",
+	Allowed:   true,
+	Patch:     validPatchIfDefaultRegionPresent,
 	PatchType: &jsonPatchType,
 }
 
@@ -300,6 +391,54 @@ func TestSecretStore(t *testing.T) {
 			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
 			getValidReview(rawWindowsBetaPodWithVolume),
 			validResponseIfWindowsVolumesPresent,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.caseName, func(t *testing.T) {
+			response := c.modifier.MutatePod(c.input)
+
+			if !reflect.DeepEqual(response, c.response) {
+				got, _ := json.MarshalIndent(response, "", "  ")
+				want, _ := json.MarshalIndent(c.response, "", "  ")
+				t.Errorf("Unexpected response. Got \n%s\n wanted \n%s", string(got), string(want))
+			}
+
+		})
+	}
+}
+
+func TestEnvUpdate(t *testing.T) {
+	testServiceAccount := &v1.ServiceAccount{}
+	testServiceAccount.Name = "default"
+	testServiceAccount.Namespace = "default"
+	testServiceAccount.Annotations = map[string]string{
+		"eks.amazonaws.com/role-arn": "arn:aws:iam::111122223333:role/s3-reader",
+	}
+
+	cases := []struct {
+		caseName string
+		modifier *Modifier
+		input    *v1beta1.AdmissionReview
+		response *v1beta1.AdmissionResponse
+	}{
+		{
+			"ValidRequestSuccessWithoutRegion",
+			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount)), WithRegion("seattle")),
+			getValidReview(rawPodWithoutVolume),
+			validResponseIfNoRegionPresent,
+		},
+		{
+			"ValidRequestSuccessWithRegion",
+			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount)), WithRegion("seattle")),
+			getValidReview(rawPodWithAWSRegion),
+			validResponseIfRegionPresent,
+		},
+		{
+			"ValidRequestSuccessWithDefaultRegion",
+			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount)), WithRegion("seattle")),
+			getValidReview(rawPodWithAWSDefaultRegion),
+			validResponseIfDefaultRegionPresent,
 		},
 	}
 


### PR DESCRIPTION
*Description of changes:*

Pods using IRSA should have information about what regions they are running in so that they can communicate with the correct AWS endpoints.
Update amazon-eks-pod-identity-webhook to set the AWS_DEFAULT_REGION environment variable into each mutated container if the value isn't set already.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
