### PR TITLE
Makefile: fix certificate approval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ deploy-config: prep-config
 	kubectl apply -f deploy/service.yaml
 	kubectl apply -f deploy/mutatingwebhook-ca-bundle.yaml
 	sleep 1
-	kubectl certificate approve $$(kubectl get csr -o jsonpath='{.items[?(@.spec.username=="system:serviceaccount:default:pod-identity-webhook")].metadata.name}')
+	kubectl certificate approve $(kubectl get csr -o jsonpath='{.items[?(@.spec.username=="system:serviceaccount:default:pod-identity-webhook")].metadata.name}')
 
 delete-config:
 	@echo 'Tearing down mutating controller and associated resources...'
@@ -90,5 +90,3 @@ clean::
 	rm -rf ./certs/
 
 .PHONY: docker push build local-serve local-request cluster-up cluster-down prep-config deploy-config delete-config clean
-
-


### PR DESCRIPTION
*Description of changes:*

Fix error in Makefile that was causing `kubectl certificate approve` to fail due to an extraneous `$` character.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
