### PR TITLE
SELF_HOSTED_SETUP.md: use correct public key

### DIFF
--- a/SELF_HOSTED_SETUP.md
+++ b/SELF_HOSTED_SETUP.md
@@ -108,12 +108,12 @@ In order to use this feature, you'll need to set the following
 [API server flags](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/).
 
 ```
-# Path to the $PUB_KEY file from the beginning. 
+# Path to the $PKCS_KEY file from the beginning. 
 #
 # This flag can be specified for multiple times.
 # There is likely already one specified for legacy service accounts, if not, 
 # it is using the default value. Find out your default value and pass it explicitly
-# (along with this $PUB_KEY), otherwise your existing tokens will fail.
+# (along with this $PKCS_KEY), otherwise your existing tokens will fail.
 --service-account-key-file
 
 # Path to the signing (private) key ($PRIV_KEY)


### PR DESCRIPTION
*Issue #, if available:* #11 

*Description of changes:* Revert change in #37 that caused a regression in the instructions for self-hosting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
