### PR TITLE
Update Makefile to poll for CSR creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ deploy-config: prep-config
 	kubectl apply -f deploy/deployment.yaml
 	kubectl apply -f deploy/service.yaml
 	kubectl apply -f deploy/mutatingwebhook-ca-bundle.yaml
-	until VAL=$$(kubectl get csr -o jsonpath='{.items[?(@.spec.username=="system:serviceaccount:default:pod-identity-webhook")].metadata.name}'); test -n $$VAR; do sleep 1; done
+	until kubectl get csr -o jsonpath='{.items[?(@.spec.username=="system:serviceaccount:default:pod-identity-webhook")].metadata.name}' | grep -m 1 "csr-"; do sleep 1 ; done
 	kubectl certificate approve $$(kubectl get csr -o jsonpath='{.items[?(@.spec.username=="system:serviceaccount:default:pod-identity-webhook")].metadata.name}')
 
 delete-config:

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,11 @@ deploy-config: prep-config
 	kubectl apply -f deploy/deployment.yaml
 	kubectl apply -f deploy/service.yaml
 	kubectl apply -f deploy/mutatingwebhook-ca-bundle.yaml
-	until kubectl get csr -o jsonpath='{.items[?(@.spec.username=="system:serviceaccount:default:pod-identity-webhook")].metadata.name}' | grep -m 1 "csr-"; do sleep 1 ; done
+	until kubectl get csr -o \
+		jsonpath='{.items[?(@.spec.username=="system:serviceaccount:default:pod-identity-webhook")].metadata.name}' | \
+		grep -m 1 "csr-"; \
+		do echo "Waiting for CSR to be created" && sleep 1 ; \
+	done
 	kubectl certificate approve $$(kubectl get csr -o jsonpath='{.items[?(@.spec.username=="system:serviceaccount:default:pod-identity-webhook")].metadata.name}')
 
 delete-config:

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ deploy-config: prep-config
 	kubectl apply -f deploy/deployment.yaml
 	kubectl apply -f deploy/service.yaml
 	kubectl apply -f deploy/mutatingwebhook-ca-bundle.yaml
-	sleep 1
+	until VAL=$$(kubectl get csr -o jsonpath='{.items[?(@.spec.username=="system:serviceaccount:default:pod-identity-webhook")].metadata.name}'); test -n $$VAR; do sleep 1; done
 	kubectl certificate approve $$(kubectl get csr -o jsonpath='{.items[?(@.spec.username=="system:serviceaccount:default:pod-identity-webhook")].metadata.name}')
 
 delete-config:


### PR DESCRIPTION
## What I Did
Improve from just a hard sleep to a polling check for the existence of an approvable CSR.

Similar to #47, but potentially more robust.

While trying to set things up with this Makefile, we were running into issues where, for various reasons, the Pod wasn't coming up fast enough to have made the CSR within 1 second. This meant that we tried to approve the CSR and failed at it since it didn't exist yet. It also led to issues where it would mask a failure of the Pod to come up for reasons like the Image not being accessible, since the Makefile would "succeed". With this system, if the Pod never comes up, the CSR is never made, and the Makefile will stall indefinitely.

## Questions/Help Wanted

I'm not totally sure I like that as a failure model, but I also didn't want to write a massive shell script in here to handle this more explicitly. If the CSR can't be approved, then the Pod won't actually work, so just having this stall out and hang doesn't seem bad.

I would also appreciate if folks have a better idea of how to query/test the values. I don't totally understand the workflow of the Webhook on the long term to know if there's other edge cases we'd want to have covered. Right now, I'm just checking that there's _any_ response at all from the request for CSRs and then relying on the specificity of the query to narrow this down to only the CSR that we care about, and then assuming that we're on a fresh cluster where there wasn't a CSR before we ran this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
