### PR TITLE
Update ecr login command for both aws-cli v1 and v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ docker:
 	docker build --no-cache -t $(IMAGE) .
 
 push: docker
-	eval $$(aws ecr get-login --registry-ids $(REGISTRY_ID) --no-include-email)
+	aws ecr get-login-password --region $(REGION) | docker login --username AWS --password-stdin $(REGISTRY_ID).dkr.ecr.$(REGION).amazonaws.com
 	docker push $(IMAGE)
 
 amazon-eks-pod-identity-webhook:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ docker:
 	docker build --no-cache -t $(IMAGE) .
 
 push: docker
-	aws ecr get-login-password --region $(REGION) | docker login --username AWS --password-stdin $(REGISTRY_ID).dkr.ecr.$(REGION).amazonaws.com
+	if ! aws ecr get-login-password --region $(REGION) | docker login --username AWS --password-stdin $(REGISTRY_ID).dkr.ecr.$(REGION).amazonaws.com; then \
+	  eval $$(aws ecr get-login --registry-ids $(REGISTRY_ID) --no-include-email); \
+	fi
 	docker push $(IMAGE)
 
 amazon-eks-pod-identity-webhook:


### PR DESCRIPTION
*Description of changes:*

`make push` does not work with aws-cli v2 because `aws ecr get-login` command has been removed. This PR will replace the login command with `aws ecr get-login-password`. It is available in v1.17.10 or later.
