### PR TITLE
Fix some lint warnings

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -206,11 +206,11 @@ func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string) []p
 	}
 
 	volume := corev1.Volume{
-		m.volName,
-		corev1.VolumeSource{
+		Name: m.volName,
+		VolumeSource: corev1.VolumeSource{
 			Projected: &corev1.ProjectedVolumeSource{
 				Sources: []corev1.VolumeProjection{
-					corev1.VolumeProjection{
+					{
 						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
 							Audience:          audience,
 							ExpirationSeconds: &m.Expiration,
@@ -223,7 +223,7 @@ func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string) []p
 	}
 
 	patch := []patchOperation{
-		patchOperation{
+		{
 			Op:    "add",
 			Path:  "/spec/volumes/0",
 			Value: volume,
@@ -232,7 +232,7 @@ func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string) []p
 
 	if pod.Spec.Volumes == nil {
 		patch = []patchOperation{
-			patchOperation{
+			{
 				Op:   "add",
 				Path: "/spec/volumes",
 				Value: []corev1.Volume{


### PR DESCRIPTION
*Description of changes:*

fixed some lint warnings.

- k8s.io/api/core/v1.Volume composite literal uses unkeyed fields
- redundant type from array, slice, or map composite literal


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
