### PR TITLE
Added AWS_STS_REGIONAL_ENDPOINTS flag/annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ deploy/deployment.yaml
 build
 /certs/
 SAMToolkit.*
+coverage.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang AS builder
 
 WORKDIR $GOPATH/src/github.com/aws/amazon-eks-pod-identity-webhook
 COPY . ./
-RUN CGO_ENABLED=0 GOOS=linux go build -v -a -installsuffix nocgo -o /webhook .
+RUN GOPROXY=direct CGO_ENABLED=0 GOOS=linux go build -o /webhook -v -a -installsuffix nocgo -ldflags="-buildid='' -w -s" .
 
 FROM scratch
 COPY ATTRIBUTIONS.txt /ATTRIBUTIONS.txt

--- a/Makefile
+++ b/Makefile
@@ -5,20 +5,23 @@ include ${BGO_MAKEFILE}
 export CGO_ENABLED=0
 export T=github.com/aws/amazon-eks-pod-identity-webhook
 UNAME_S = $(shell uname -s)
-GO_INSTALL_FLAGS = -ldflags="-s -w"
+GO_LDFLAGS = -ldflags='-s -w -buildid=""'
 
 install:: build
 ifeq ($(UNAME_S), Darwin)
-	GOOS=darwin GOARCH=amd64 go build -o build/gopath/bin/darwin_amd64/amazon-eks-pod-identity-webhook $(GO_INSTALL_FLAGS) $V $T
+	GOOS=darwin GOARCH=amd64 go build -o build/gopath/bin/darwin_amd64/amazon-eks-pod-identity-webhook $(GO_LDFLAGS) $V $T
 endif
-	GOOS=linux GOARCH=amd64 go build -o build/gopath/bin/linux_amd64/amazon-eks-pod-identity-webhook $(GO_INSTALL_FLAGS) $V $T
-
+	GOOS=linux GOARCH=amd64 go build -o build/gopath/bin/linux_amd64/amazon-eks-pod-identity-webhook $(GO_LDFLAGS) $V $T
 
 # Generic make
 REGISTRY_ID?=602401143452
 IMAGE_NAME?=eks/pod-identity-webhook
 REGION?=us-west-2
 IMAGE?=$(REGISTRY_ID).dkr.ecr.$(REGION).amazonaws.com/$(IMAGE_NAME)
+
+test:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out
 
 docker:
 	@echo 'Building image $(IMAGE)...'
@@ -94,7 +97,7 @@ delete-config:
 
 clean::
 	rm -rf ./amazon-eks-pod-identity-webhook
-	rm -rf ./certs/
+	rm -rf ./certs/ coverage.out
 
 .PHONY: docker push build local-serve local-request cluster-up cluster-down prep-config deploy-config delete-config clean
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ This webhook is for mutating pods that will require AWS IAM access.
       {
        "Effect": "Allow",
        "Principal": {
-        "Federated": "arn:aws:iam::111122223333:oidc-provider/oidc.us-west-2.eks.amazonaws.com/624a142e-43fc-4a4e-9a65-0adbfe9d6a85"
+        "Federated": "arn:aws:iam::111122223333:oidc-provider/oidc.REGION.eks.amazonaws.com/CLUSTER_ID"
        },
        "Action": "sts:AssumeRoleWithWebIdentity",
        "Condition": {
         "__doc_comment": "scope the role to the service account (optional)",
         "StringEquals": {
-         "oidc.us-west-2.eks.amazonaws.com/624a142e-43fc-4a4e-9a65-0adbfe9d6a85:sub": "system:serviceaccount:default:my-serviceaccount"
+         "oidc.REGION.eks.amazonaws.com/CLUSTER_ID:sub": "system:serviceaccount:default:my-serviceaccount"
         },
         "__doc_comment": "scope the role to a namespace (optional)",
         "StringLike": {
-         "oidc.us-west-2.eks.amazonaws.com/624a142e-43fc-4a4e-9a65-0adbfe9d6a85:sub": "system:serviceaccount:default:*"
+         "oidc.REGION.eks.amazonaws.com/CLUSTER_ID:sub": "system:serviceaccount:default:*"
         }
        }
       }
@@ -48,6 +48,11 @@ This webhook is for mutating pods that will require AWS IAM access.
       namespace: default
       annotations:
         eks.amazonaws.com/role-arn: "arn:aws:iam::111122223333:role/s3-reader"
+        # optional: Defaults to "sts.amazonaws.com" if not set
+        eks.amazonaws.com/audience: "sts.amazonaws.com"
+        # optional: When set to "true", adds AWS_STS_REGIONAL_ENDPOINTS env var
+        #   to containers
+        eks.amazonaws.com/sts-regional-endpoints: "true"
     ```
 4. All new pod pods launched using this Service Account will be modified to use
    IAM for pods. Below is an example pod spec with the environment variables and
@@ -58,9 +63,18 @@ This webhook is for mutating pods that will require AWS IAM access.
     metadata:
       name: my-pod
       namespace: default
+      annotations:
+        # optional: A comma-separated list of initContainers and container names
+        #   to skip adding volumes and environemnt variables
+        eks.amazonaws.com/skip-containers: "init-first,sidecar"
     spec:
       serviceAccountName: my-serviceaccount
+      initContainers:
+      - name: init-first
+        image: container-image:version
       containers:
+      - name: sidecar
+        image: container-image:version
       - name: container-name
         image: container-image:version
     ### Everything below is added by the webhook ###
@@ -73,6 +87,8 @@ This webhook is for mutating pods that will require AWS IAM access.
           value: "arn:aws:iam::111122223333:role/s3-reader"
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+        - name: AWS_STS_REGIONAL_ENDPOINTS
+          value: "regional"
         volumeMounts:
         - mountPath: "/var/run/secrets/eks.amazonaws.com/serviceaccount/"
           name: aws-token
@@ -85,7 +101,7 @@ This webhook is for mutating pods that will require AWS IAM access.
               expirationSeconds: 86400
               path: token
     ```
-   
+
 ### Usage with Windows container workloads
 
 To ensure workloads are scheduled on windows nodes have the right environment variables, they must have a `nodeSelector` targeting windows it must run on.  Workloads targeting windows nodes using `nodeAffinity` are currently not supported.
@@ -125,12 +141,14 @@ Usage of amazon-eks-pod-identity-webhook:
       --log_file string                  If non-empty, use this log file
       --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
       --logtostderr                      log to standard error instead of files (default true)
+      --metrics-port int                 Port to listen on for metrics and healthz (http) (default 9999)
       --namespace string                 (in-cluster) The namespace name this webhook and the tls secret resides in (default "eks")
       --port int                         Port to listen on (default 443)
       --service-name string              (in-cluster) The service name fronting this webhook (default "pod-identity-webhook")
       --skip_headers                     If true, avoid header prefixes in the log messages
       --skip_log_headers                 If true, avoid headers when openning log files
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+      --sts-regional-endpoint false      Whether to inject the AWS_STS_REGIONAL_ENDPOINTS=regional env var in mutated pods. Defaults to false.
       --tls-cert string                  (out-of-cluster) TLS certificate file path (default "/etc/webhook/certs/tls.crt")
       --tls-key string                   (out-of-cluster) TLS key file path (default "/etc/webhook/certs/tls.key")
       --tls-secret string                (in-cluster) The secret name for storing the TLS serving cert (default "pod-identity-webhook")
@@ -146,6 +164,18 @@ Usage of amazon-eks-pod-identity-webhook:
 
 When the `aws-default-region` flag is set this webhook will inject `AWS_DEFAULT_REGION` and `AWS_REGION` in mutated containers if `AWS_DEFAULT_REGION` and `AWS_REGION` are not already set.
 
+### AWS_STS_REGIONAL_ENDPOINTS Injection
+
+When the `sts-regional-endpoint` flag is set to `true`, the webhook will
+inject the environment variable `AWS_STS_REGIONAL_ENDPOINTS` with the value set
+to `regional`. This environment variable will configure the AWS SDKs to perform
+the `sts:AssumeRoleWithWebIdentity` call to get credentials from the regional
+endpoint, instead of the global endpoint in `us-east-1`. This is desirable in
+almost all cases, unless the STS regional endpoint is [disabled in your
+account](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html).
+
+You can also enable this per-service account with the annotation
+`eks.amazonaws.com/sts-regional-endpoint` set to `"true"`.
 
 ## Container Images
 
@@ -169,9 +199,6 @@ This will:
 For self-hosted API server configuration, see see [SELF_HOSTED_SETUP.md](/SELF_HOSTED_SETUP.md)
 
 ### On API server
-TODO
-
-## Development
 TODO
 
 ## Code of Conduct

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/evanphx/json-patch v4.4.0+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
+	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
@@ -13,11 +14,13 @@ require (
 	github.com/json-iterator/go v1.1.6 // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v0.9.3
 	github.com/spf13/pflag v1.0.3
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/square/go-jose.v2 v2.5.1
 	k8s.io/api v0.0.0-20190606204050-af9c91bd2759
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.1-0.20190606204521-b8faab9c5193+incompatible
@@ -25,5 +28,5 @@ require (
 	k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208 // indirect
 	k8s.io/kubernetes v1.14.3
 	k8s.io/utils v0.0.0-20190529001817-6999998975a7 // indirect
-	sigs.k8s.io/yaml v1.1.0 // indirect
+	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -122,6 +124,8 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZe
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09 h1:6Cq5LXQ/D2J5E7sYJemWSQApczOzY1rxSp8TWloyxIY=
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
@@ -129,6 +133,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
+gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 k8s.io/api v0.0.0-20190606204050-af9c91bd2759 h1:T8xTLSBgKsq1bkiAwG9xamEydWVpBv9fHl5S/TDh3OU=

--- a/pkg/annotations.go
+++ b/pkg/annotations.go
@@ -1,0 +1,27 @@
+/*
+  Copyright 2010 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  A copy of the License is located at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  or in the "license" file accompanying this file. This file is distributed
+  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing
+  permissions and limitations under the License.
+*/
+package pkg
+
+const (
+	// The audience annotation
+	AudienceAnnotation = "audience"
+	// Role ARN annotation
+	RoleARNAnnotation = "role-arn"
+	// A true/false value to add AWS_STS_REGIONAL_ENDPOINTS. Overrides any setting on the webhook
+	UseRegionalSTSAnnotation = "sts-regional-endpoints"
+
+	// A comma-separated list of container names to skip adding environment variables and volumes to. Applies to `initContainers` and `containers`
+	SkipContainersAnnotation = "skip-containers"
+)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -11,7 +11,10 @@ func TestSaCache(t *testing.T) {
 	testSA.Name = "default"
 	testSA.Namespace = "default"
 	roleArn := "arn:aws:iam::111122223333:role/s3-reader"
-	testSA.Annotations = map[string]string{"eks.amazonaws.com/role-arn": roleArn}
+	testSA.Annotations = map[string]string{
+		"eks.amazonaws.com/role-arn":               roleArn,
+		"eks.amazonaws.com/sts-regional-endpoints": "true",
+	}
 
 	cache := &serviceAccountCache{
 		cache:            map[string]*CacheResponse{},
@@ -19,20 +22,22 @@ func TestSaCache(t *testing.T) {
 		annotationPrefix: "eks.amazonaws.com",
 	}
 
-	role, aud := cache.Get("default", "default")
+	role, aud, useRegionalSTS := cache.Get("default", "default")
 
 	if role != "" || aud != "" {
-		t.Errorf("Expected role and aud to be empty, got %s, %s", role, aud)
+		t.Errorf("Expected role and aud to be empty, got %s, %s, %t", role, aud, useRegionalSTS)
 	}
 
 	cache.addSA(testSA)
 
-	role, aud = cache.Get("default", "default")
+	role, aud, useRegionalSTS = cache.Get("default", "default")
 	if role != roleArn {
 		t.Errorf("Expected role to be %s, got %s", roleArn, role)
 	}
 	if aud != "sts.amazonaws.com" {
 		t.Errorf("Expected aud to be sts.amzonaws.com, got %s", aud)
 	}
-
+	if useRegionalSTS {
+		t.Error("Expected regional STS to be true, got false")
+	}
 }

--- a/pkg/handler/handler_pod_test.go
+++ b/pkg/handler/handler_pod_test.go
@@ -1,0 +1,158 @@
+/*
+  Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  A copy of the License is located at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  or in the "license" file accompanying this file. This file is distributed
+  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing
+  permissions and limitations under the License.
+*/
+
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+var fixtureDir = "./testdata"
+
+var (
+	// SkipAnnotation means "don't test this file"
+	skipAnnotation = "testing.eks.amazonaws.com/skip"
+	// Expected patch output
+	expectedPatchAnnotation = "testing.eks.amazonaws.com/expectedPatch"
+
+	// Service Account annotation values
+	roleArnSAAnnotation   = "testing.eks.amazonaws.com/serviceAccount/roleArn"
+	audienceAnnotation    = "testing.eks.amazonaws.com/serviceAccount/audience"
+	saInjectSTSAnnotation = "testing.eks.amazonaws.com/serviceAccount/sts-regional-endpoints"
+
+	// Handler values
+	handlerMountPathAnnotation  = "testing.eks.amazonaws.com/handler/mountPath"
+	handlerExpirationAnnotation = "testing.eks.amazonaws.com/handler/expiration"
+	handlerRegionAnnotation     = "testing.eks.amazonaws.com/handler/region"
+	handlerSTSAnnotation        = "testing.eks.amazonaws.com/handler/injectSTS"
+)
+
+func getModifierFromPod(pod corev1.Pod) (*Modifier, error) {
+	modifiers := []ModifierOpt{}
+
+	if path, ok := pod.Annotations[handlerMountPathAnnotation]; ok {
+		modifiers = append(modifiers, WithMountPath(path))
+	}
+	if expStr, ok := pod.Annotations[handlerExpirationAnnotation]; ok {
+		expInt, err := strconv.Atoi(expStr)
+		if err != nil {
+			return nil, err
+		}
+		modifiers = append(modifiers, WithExpiration(int64(expInt)))
+	}
+	if region, ok := pod.Annotations[handlerRegionAnnotation]; ok {
+		modifiers = append(modifiers, WithRegion(region))
+	}
+	if stsAnnotation, ok := pod.Annotations[handlerSTSAnnotation]; ok {
+		value, err := strconv.ParseBool(stsAnnotation)
+		if err != nil {
+			return nil, err
+		}
+		modifiers = append(modifiers, WithRegionalSTS(value))
+	}
+	return NewModifier(modifiers...), nil
+}
+
+func TestHandlePod(t *testing.T) {
+	err := filepath.Walk(fixtureDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			t.Errorf("Error while walking test fixtures: %v", err)
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml") {
+			pod, err := parseFile(filepath.Join("./", path))
+			if err != nil {
+				t.Errorf("Error while parsing file %s: %v", info.Name(), err)
+				return err
+			}
+			if skipStr, ok := pod.Annotations[skipAnnotation]; ok {
+				skip, _ := strconv.ParseBool(skipStr)
+				if skip {
+					return nil
+				}
+			}
+
+			t.Run(fmt.Sprintf("Pod %s in file %s", pod.Name, path), func(t *testing.T) {
+				modifier, err := getModifierFromPod(*pod)
+				if err != nil {
+					t.Errorf("Error creating modifier: %v", err)
+				}
+				var roleARN string
+				if role, ok := pod.Annotations[roleArnSAAnnotation]; ok {
+					roleARN = role
+				}
+				audience := "sts.amazonaws.com"
+				if aud, ok := pod.Annotations[audienceAnnotation]; ok {
+					audience = aud
+				}
+
+				useRegionalSTS := modifier.RegionalSTSEndpoint
+				if useRegionalSTSstr, ok := pod.Annotations[saInjectSTSAnnotation]; ok {
+					useRegionalSTS, err = strconv.ParseBool(useRegionalSTSstr)
+					if err != nil {
+						t.Errorf("Error parsing annotation %s: %v", saInjectSTSAnnotation, err)
+					}
+				}
+
+				patchBytes, err := json.Marshal(modifier.updatePodSpec(pod, roleARN, audience, useRegionalSTS))
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				expectedPatchStr, ok := pod.Annotations[expectedPatchAnnotation]
+				if !ok && (len(patchBytes) == 0 || patchBytes == nil) {
+					return
+				}
+
+				if bytes.Compare(patchBytes, []byte(expectedPatchStr)) != 0 {
+					t.Errorf("Expected patch didn't match: \nGot\n\t%v\nWanted:\n\t%v\n",
+						string(patchBytes),
+						expectedPatchStr,
+					)
+				}
+
+			})
+			return nil
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("Error while walking test fixtures: %v", err)
+	}
+}
+
+// Read in the first pod in the file
+func parseFile(filename string) (*corev1.Pod, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	pod := &corev1.Pod{}
+	err = yaml.Unmarshal(data, pod)
+	return pod, err
+}

--- a/pkg/handler/testdata/betaWindowsPodWithoutVolumes.pod.yaml
+++ b/pkg/handler/testdata/betaWindowsPodWithoutVolumes.pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  uid: be8695c4-4ad0-4038-8786-c508853aa255
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"C:\\var\\run\\secrets\\eks.amazonaws.com\\serviceaccount\\token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  nodeSelector:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: windows
+  serviceAccountName: default
+

--- a/pkg/handler/testdata/initPodNeedsRegion.pod.yaml
+++ b/pkg/handler/testdata/initPodNeedsRegion.pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/handler/region: "seattle"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"seattle"},{"name":"AWS_REGION","value":"seattle"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]},{"op":"add","path":"/spec/initContainers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"seattle"},{"name":"AWS_REGION","value":"seattle"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  initContainers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default

--- a/pkg/handler/testdata/rawPodHasAll.pod.yaml
+++ b/pkg/handler/testdata/rawPodHasAll.pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws-cn:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/handler/injectSTS: "true"
+    testing.eks.amazonaws.com/handler/region: "cn-north-1"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_REGION","value":"cn-northwest-1"},{"name":"AWS_STS_REGIONAL_ENDPOINTS","value":"regional"},{"name":"AWS_ROLE_ARN","value":"arn:aws-cn:iam::111122223333:role/s3-reader"}],"resources":{}}]}]'
+spec:
+  containers:
+  - env:
+    - name: AWS_REGION
+      value: cn-northwest-1
+    - name: AWS_STS_REGIONAL_ENDPOINTS
+      value: regional
+    - name: AWS_ROLE_ARN
+      value: 'arn:aws-cn:iam::111122223333:role/s3-reader'
+    image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default

--- a/pkg/handler/testdata/rawPodHasSTS.pod.yaml
+++ b/pkg/handler/testdata/rawPodHasSTS.pod.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws-cn:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/handler/injectSTS: "true"
+    testing.eks.amazonaws.com/handler/region: "cn-north-1"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_REGION","value":"cn-northwest-1"},{"name":"AWS_STS_REGIONAL_ENDPOINTS","value":"regional"},{"name":"AWS_ROLE_ARN","value":"arn:aws-cn:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  containers:
+  - env:
+    - name: AWS_REGION
+      value: cn-northwest-1
+    - name: AWS_STS_REGIONAL_ENDPOINTS
+      value: regional
+    image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default

--- a/pkg/handler/testdata/rawPodHasVolumeMount.pod.yaml
+++ b/pkg/handler/testdata/rawPodHasVolumeMount.pod.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","mountPath":""}]}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+    volumeMounts:
+      - name: aws-iam-token
+        path: /path/to/token
+  serviceAccountName: default
+  volumes:
+    - name: aws-iam-token
+      hostPath:
+        path: /path/to/token

--- a/pkg/handler/testdata/rawPodNeedsRegion.pod.yaml
+++ b/pkg/handler/testdata/rawPodNeedsRegion.pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/handler/region: "seattle"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"seattle"},{"name":"AWS_REGION","value":"seattle"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default

--- a/pkg/handler/testdata/rawPodNeedsSTS.pod.yaml
+++ b/pkg/handler/testdata/rawPodNeedsSTS.pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws-cn:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/handler/injectSTS: "true"
+    testing.eks.amazonaws.com/handler/region: "cn-north-1"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_STS_REGIONAL_ENDPOINTS","value":"regional"},{"name":"AWS_DEFAULT_REGION","value":"cn-north-1"},{"name":"AWS_REGION","value":"cn-north-1"},{"name":"AWS_ROLE_ARN","value":"arn:aws-cn:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default

--- a/pkg/handler/testdata/rawPodNoSTSAnnotationOverride.pod.yaml
+++ b/pkg/handler/testdata/rawPodNoSTSAnnotationOverride.pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/serviceAccount/sts-regional-endpoints: "false"  # SA annotation should override flag
+    testing.eks.amazonaws.com/handler/injectSTS: "true"
+    testing.eks.amazonaws.com/handler/region: "us-east-1"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"us-east-1"},{"name":"AWS_REGION","value":"us-east-1"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default

--- a/pkg/handler/testdata/rawPodRegionPresent.pod.yaml
+++ b/pkg/handler/testdata/rawPodRegionPresent.pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_REGION","value":"paris"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  containers:
+  - env:
+    - name: AWS_REGION
+      value: paris
+    image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default

--- a/pkg/handler/testdata/rawPodSkip.pod.yaml
+++ b/pkg/handler/testdata/rawPodSkip.pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/handler/region: "us-west-2"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"sidecar","image":"amazonlinux","resources":{}},{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"already-defined"},{"name":"AWS_DEFAULT_REGION","value":"us-west-2"},{"name":"AWS_REGION","value":"us-west-2"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+    # Pod Annotation
+    eks.amazonaws.com/skip-containers: "sidecar"
+spec:
+  containers:
+  - image: amazonlinux
+    name: sidecar
+  - image: amazonlinux
+    name: balajilovesoreos
+    env:
+    - name: AWS_ROLE_ARN
+      value: already-defined
+  serviceAccountName: default

--- a/pkg/handler/testdata/rawPodWithInitContainer.pod.yaml
+++ b/pkg/handler/testdata/rawPodWithInitContainer.pod.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  uid: be8695c4-4ad0-4038-8786-c508853aa255
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/handler/region: "seattle"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"seattle"},{"name":"AWS_REGION","value":"seattle"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]},{"op":"add","path":"/spec/initContainers","value":[{"name":"initcontainer","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"seattle"},{"name":"AWS_REGION","value":"seattle"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  initContainers:
+  - image: amazonlinux
+    name: initcontainer
+  serviceAccountName: default
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default

--- a/pkg/handler/testdata/rawPodWithVolumes.pod.yaml
+++ b/pkg/handler/testdata/rawPodWithVolumes.pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  uid: be8695c4-4ad0-4038-8786-c508853aa255
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes/0","value":{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default
+  volumes:
+  - name: my-volume

--- a/pkg/handler/testdata/rawPodWithoutVolumes.pod.yaml
+++ b/pkg/handler/testdata/rawPodWithoutVolumes.pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default

--- a/pkg/handler/testdata/windowsPodWithoutVolumes.pod.yaml
+++ b/pkg/handler/testdata/windowsPodWithoutVolumes.pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  uid: be8695c4-4ad0-4038-8786-c508853aa255
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"C:\\var\\run\\secrets\\eks.amazonaws.com\\serviceaccount\\token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  nodeSelector:
+    kubernetes.io/arch: amd64
+    kubernetes.io/os: windows
+  serviceAccountName: default
+


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

The default for most AWS v1 SDKs is to use the global STS endpoint (`https://sts.amazonaws.com`, hosted in `us-east-1`) when talking to STS, resulting in a cross-region call for anything not in `us-east-1` just to get credentials. (some v2 SDKs such as [Java v2](https://github.com/aws/aws-sdk-java-v2/issues/1745) use regional). The way to force AWS SDKs to use the regional STS endpoint is to add the `AWS_STS_REGIONAL_ENDPOINTS` environment variable and set the value to `regional`. 

For applications running in Kubernetes pods using this webhook, this setting can now be automatically configured by adding the ServiceAccount annotation `eks.amazonaws.com/sts-regional-endpoints` with a value of `"true"`, or if operating this webhook on a cluster, setting the webhook flag `--sts-regional-endpoint=true`. 

If the webhook's flag value is set to regional (`--sts-regional-endpoint=true`), but the environment variable is not desired, individual ServiceAccounts can opt-out by setting the annotation to `eks.amazonaws.com/sts-regional-endpoints: "false"`.

Note that IAM administrators [can disable regional STS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html), and any applications that attempt to use a regional STS endpoint on a disabled region will  get an error.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
