### PR TITLE
Update Makefile to delete created tls cert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ delete-config:
 	kubectl delete -f deploy/service.yaml
 	kubectl delete -f deploy/deployment.yaml
 	kubectl delete -f deploy/auth.yaml
+	kubectl delete secret pod-identity-webhook
 
 clean::
 	rm -rf ./amazon-eks-pod-identity-webhook


### PR DESCRIPTION
This cert is tied to the deployment, and causes issues if you 
```
cluster-up
delete-config
cluster-up
```
resulting in loop of `kubectl certificate approve $$(kubectl get csr -o jsonpath='{.items[?(@.spec.username=="system:serviceaccount:default:pod-identity-webhook")].metadata.name}')`

*Issue #, if available:*
N/A
*Description of changes:*

Add delete of secret in Makefile
