### PR TITLE
Default --tls-cert to tls.crt to match kubernetes secret TLS field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ certs/tls.key:
 		-x509 \
 		-newkey rsa:2048 \
 		-keyout certs/tls.key \
-		-out certs/tls.cert \
+		-out certs/tls.crt \
 		-days 365 \
 		-nodes \
 		-subj "/CN=127.0.0.1"
@@ -49,7 +49,7 @@ local-serve: amazon-eks-pod-identity-webhook certs/tls.key
 		--port 8443 \
 		--in-cluster=false \
 		--tls-key=./certs/tls.key \
-		--tls-cert=./certs/tls.cert \
+		--tls-cert=./certs/tls.crt \
 		--kubeconfig=$$HOME/.kube/config
 
 local-request:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Usage of amazon-eks-pod-identity-webhook:
       --skip_headers                     If true, avoid header prefixes in the log messages
       --skip_log_headers                 If true, avoid headers when openning log files
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-      --tls-cert string                  (out-of-cluster) TLS certificate file path (default "/etc/webhook/certs/tls.cert")
+      --tls-cert string                  (out-of-cluster) TLS certificate file path (default "/etc/webhook/certs/tls.crt")
       --tls-key string                   (out-of-cluster) TLS key file path (default "/etc/webhook/certs/tls.key")
       --tls-secret string                (in-cluster) The secret name for storing the TLS serving cert (default "pod-identity-webhook")
       --token-audience string            The default audience for tokens. Can be overridden by annotation (default "sts.amazonaws.com")

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 	kubeconfig := flag.String("kubeconfig", "", "(out-of-cluster) Absolute path to the API server kubeconfig file")
 	apiURL := flag.String("kube-api", "", "(out-of-cluster) The url to the API server")
 	tlsKeyFile := flag.String("tls-key", "/etc/webhook/certs/tls.key", "(out-of-cluster) TLS key file path")
-	tlsCertFile := flag.String("tls-cert", "/etc/webhook/certs/tls.cert", "(out-of-cluster) TLS certificate file path")
+	tlsCertFile := flag.String("tls-cert", "/etc/webhook/certs/tls.crt", "(out-of-cluster) TLS certificate file path")
 
 	// in-cluster TLS options
 	inCluster := flag.Bool("in-cluster", true, "Use in-cluster authentication and certificate request API")


### PR DESCRIPTION
*Description of changes:*

kubernetes secrets use file names `tls.key` for the key and `tls.crt` for the certificate; match them with our defaults.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
