### PR TITLE
deploy: add sideEffects to webhook

### DIFF
--- a/deploy/mutatingwebhook.yaml
+++ b/deploy/mutatingwebhook.yaml
@@ -6,6 +6,7 @@ metadata:
 webhooks:
 - name: pod-identity-webhook.amazonaws.com
   failurePolicy: Ignore
+  sideEffects: None
   clientConfig:
     service:
       name: pod-identity-webhook


### PR DESCRIPTION
fixes #46

Adds `sideEffects: None` to the `MutatingWebhookConfiguration` definition so that dry run operations will succeed.