### PR TITLE
Add github worflow to automate docker image creation

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -1,0 +1,41 @@
+name: Container Images
+
+on: push
+jobs:
+  build:
+    # this is to prevent the job to run at forked projects
+    if: github.repository == 'aws/amazon-eks-pod-identity-webhook'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: crazy-max/ghaction-docker-buildx@v3
+      with:
+        buildx-version: latest
+        qemu-version: latest
+    - name: Build container and push to Dockerhub registry
+      run: |
+        BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
+        SHORT_SHA=$(echo $GITHUB_SHA | cut -c -7)
+        REPO=amazon/amazon-eks-pod-identity-webhook
+        if [ "$BRANCH" = "master" ]; then
+          TAG=$SHORT_SHA
+        else
+          TAG=$BRANCH
+        fi
+        docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+
+        docker buildx build \
+              -t $REPO:$TAG \
+              --platform=linux/amd64,linux/arm64 \
+              --progress plain \
+              --push .
+        if [ "$BRANCH" = "master" ]; then
+          docker buildx build \
+                -t $REPO:master \
+                --platform=linux/amd64,linux/arm64 \
+                --progress plain \
+                --push .
+        fi
+


### PR DESCRIPTION
Add a github workflow that triggers a new build of amazon-eks-pod-identity-webhook on each commit.
The new image is then pushed to dockerhub.
Tagged commits produce a tagged docker image, other commits produce a docker image tagged with a short commit hash.

Issue #5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
