### PR TITLE
Support `fs-group` annotation to add PodSecurityPolicies for non-root containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ This webhook is for mutating pods that will require AWS IAM access.
       annotations:
         eks.amazonaws.com/role-arn: "arn:aws:iam::111122223333:role/s3-reader"
     ```
-4. All new pod pods launched using this Service Account will be modified to use
+4. Optionally, add the `eks.amazonaws.com/fs-group` annotation to the service
+   account or to the pod's annotations with an integer GID. This will add a
+   `PodSecurityPolicy` with that GID as the `fsGroup` to applicable pods. This
+   is necessary for non-root containers to access the projected service account
+   token which will be owned by root with 0600 permissions.
+5. All new pod pods launched using this Service Account will be modified to use
    IAM for pods. Below is an example pod spec with the environment variables and
    volume fields added by the webhook.
     ```yaml

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func main() {
 	saCache.Start()
 
 	mod := handler.NewModifier(
+		handler.WithAnnotationPrefix(*annotationPrefix),
 		handler.WithExpiration(*tokenExpiration),
 		handler.WithMountPath(*mountPath),
 		handler.WithServiceAccountCache(saCache),
@@ -123,7 +124,6 @@ func main() {
 	metricsMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "ok")
 	})
-
 
 	tlsConfig := &tls.Config{}
 
@@ -180,8 +180,8 @@ func main() {
 	handler.ShutdownOnTerm(server, time.Duration(10)*time.Second)
 
 	metricsServer := &http.Server{
-		Addr:      metricsAddr,
-		Handler:   metricsMux,
+		Addr:    metricsAddr,
+		Handler: metricsMux,
 	}
 
 	go func() {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"fmt"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -11,7 +12,11 @@ func TestSaCache(t *testing.T) {
 	testSA.Name = "default"
 	testSA.Namespace = "default"
 	roleArn := "arn:aws:iam::111122223333:role/s3-reader"
-	testSA.Annotations = map[string]string{"eks.amazonaws.com/role-arn": roleArn}
+	var fsGroup int64 = 12345
+	testSA.Annotations = map[string]string{
+		"eks.amazonaws.com/role-arn": roleArn,
+		"eks.amazonaws.com/fs-group": fmt.Sprintf("%d", fsGroup),
+	}
 
 	cache := &serviceAccountCache{
 		cache:            map[string]*CacheResponse{},
@@ -19,20 +24,21 @@ func TestSaCache(t *testing.T) {
 		annotationPrefix: "eks.amazonaws.com",
 	}
 
-	role, aud := cache.Get("default", "default")
-
-	if role != "" || aud != "" {
-		t.Errorf("Expected role and aud to be empty, got %s, %s", role, aud)
+	role, aud, fsg := cache.Get("default", "default")
+	if role != "" || aud != "" || fsg != nil {
+		t.Errorf("Expected role, aud and fsg to be empty, got %s, %s, %d", role, aud, *fsg)
 	}
 
 	cache.addSA(testSA)
 
-	role, aud = cache.Get("default", "default")
+	role, aud, fsg = cache.Get("default", "default")
 	if role != roleArn {
 		t.Errorf("Expected role to be %s, got %s", roleArn, role)
 	}
 	if aud != "sts.amazonaws.com" {
 		t.Errorf("Expected aud to be sts.amzonaws.com, got %s", aud)
 	}
-
+	if *fsg != fsGroup {
+		t.Errorf("Expected fsg to be %d, got %d", fsGroup, *fsg)
+	}
 }

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -338,6 +338,75 @@ var rawPodWithAWSDefaultRegion = []byte(`
 }
 `)
 
+var rawPodWithoutFSGroup = []byte(`
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "balajilovesoreos",
+	"uid": "be8695c4-4ad0-4038-8786-c508853aa255"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"image": "amazonlinux",
+		"name": "balajilovesoreos"
+	  }
+	],
+	"serviceAccountName": "fsgroup"
+  }
+}
+`)
+
+var rawPodWithFSGroup = []byte(`
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "balajilovesoreos",
+	"uid": "be8695c4-4ad0-4038-8786-c508853aa255"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"image": "amazonlinux",
+		"name": "balajilovesoreos"
+	  }
+	],
+    "securityContext": {
+      "fsGroup": 54321
+    },
+	"serviceAccountName": "fsgroup"
+  }
+}
+`)
+
+var rawPodWithFSGroupAnnotation = []byte(`
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "annotations": {
+      "eks.amazonaws.com/fs-group": "33333"
+    },
+	"name": "balajilovesoreos",
+	"uid": "be8695c4-4ad0-4038-8786-c508853aa255"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"image": "amazonlinux",
+		"name": "balajilovesoreos"
+	  }
+	],
+    "securityContext": {
+      "runAsUser": 2000
+    },
+	"serviceAccountName": "fsgroup"
+  }
+}
+`)
+
 func getValidReview(pod []byte) *v1beta1.AdmissionReview {
 	return &v1beta1.AdmissionReview{
 		Request: &v1beta1.AdmissionRequest{
@@ -375,6 +444,10 @@ var validPatchIfNoRegionPresent = []byte(`[{"op":"add","path":"/spec/volumes","v
 var validPatchIfRegionPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_REGION","value":"paris"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 var validPatchIfDefaultRegionPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"paris"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 var validPatchIfInitContainerPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"seattle"},{"name":"AWS_REGION","value":"seattle"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]},{"op":"add","path":"/spec/initContainers","value":[{"name":"initcontainer","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"seattle"},{"name":"AWS_REGION","value":"seattle"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
+
+var validPatchIfNoFSGroupPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]},{"op":"add","path":"/spec/securityContext","value":{"fsGroup":12345}}]`)
+var validPatchIfFSGroupPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
+var validPatchIfFSGroupAnnotationPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]},{"op":"add","path":"/spec/securityContext","value":{"runAsUser":2000,"fsGroup":33333}}]`)
 
 var jsonPatchType = v1beta1.PatchType("JSONPatch")
 
@@ -445,6 +518,27 @@ var validResponseIfInitContainerPresent = &v1beta1.AdmissionResponse{
 	UID:       "",
 	Allowed:   true,
 	Patch:     validPatchIfInitContainerPresent,
+	PatchType: &jsonPatchType,
+}
+
+var validResponseIfNoFSGroupPresent = &v1beta1.AdmissionResponse{
+	UID:       "",
+	Allowed:   true,
+	Patch:     validPatchIfNoFSGroupPresent,
+	PatchType: &jsonPatchType,
+}
+
+var validResponseIfFSGroupPresent = &v1beta1.AdmissionResponse{
+	UID:       "",
+	Allowed:   true,
+	Patch:     validPatchIfFSGroupPresent,
+	PatchType: &jsonPatchType,
+}
+
+var validResponseIfFSGroupAnnotationPresent = &v1beta1.AdmissionResponse{
+	UID:       "",
+	Allowed:   true,
+	Patch:     validPatchIfFSGroupAnnotationPresent,
 	PatchType: &jsonPatchType,
 }
 
@@ -575,6 +669,55 @@ func TestEnvUpdate(t *testing.T) {
 			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount)), WithRegion("seattle")),
 			getValidReview(rawPodWithInitContainer),
 			validResponseIfInitContainerPresent,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.caseName, func(t *testing.T) {
+			response := c.modifier.MutatePod(c.input)
+
+			if !reflect.DeepEqual(response, c.response) {
+				got, _ := json.MarshalIndent(response, "", "  ")
+				want, _ := json.MarshalIndent(c.response, "", "  ")
+				t.Errorf("Unexpected response. Got \n%s\n wanted \n%s", string(got), string(want))
+			}
+
+		})
+	}
+}
+
+func TestFSGroupUpdate(t *testing.T) {
+	testServiceAccount := &v1.ServiceAccount{}
+	testServiceAccount.Name = "fsgroup"
+	testServiceAccount.Namespace = "default"
+	testServiceAccount.Annotations = map[string]string{
+		"eks.amazonaws.com/role-arn": "arn:aws:iam::111122223333:role/s3-reader",
+		"eks.amazonaws.com/fs-group": "12345",
+	}
+
+	cases := []struct {
+		caseName string
+		modifier *Modifier
+		input    *v1beta1.AdmissionReview
+		response *v1beta1.AdmissionResponse
+	}{
+		{
+			"ValidRequestSuccessWithoutFSGroup",
+			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
+			getValidReview(rawPodWithoutFSGroup),
+			validResponseIfNoFSGroupPresent,
+		},
+		{
+			"ValidRequestSuccessWithFSGroup",
+			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
+			getValidReview(rawPodWithFSGroup),
+			validResponseIfFSGroupPresent,
+		},
+		{
+			"ValidRequestSuccessWithFSGroupAnnotation",
+			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount))),
+			getValidReview(rawPodWithFSGroupAnnotation),
+			validResponseIfFSGroupAnnotationPresent,
 		},
 	}
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

A barrier to entry to using service account token volume projection is its `root` ownership with `0600` permissions by default (not customizable natively until Kubernetes v1.19?).

This leave two options, each with downsides:
- Run the containers as `root` (not great from a security perspective)
- Add a `securityContext/fsGroup` to the pod spec to grant a non-root container user access to the projected token (This is potentially difficult when integrating with upstream code or Helm charts).

This PR adds the ability to specify an `eks.amazonaws.com/fs-group` annotation on either the service account or the pod. The mutating webhook will add a `securityContext/fsGroup` in addition to the volume, mount & container env updates.
- If `securityContext/fsGroup` is already configured on a pod, this does nothing. Existing fsGroup GID on the pod spec takes precedence
- If the annotation is present on both the pod & its service account, the pod's annotation takes precedence

I've added unit tests in addition to manually testing all the configuration scenarios in a local development environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
