### PR TITLE
Add support for external TLS renewal

### DIFF
--- a/main.go
+++ b/main.go
@@ -200,6 +200,7 @@ func main() {
 		Addr:      metricsAddr,
 		Handler:   metricsMux,
 	}
+	handler.ShutdownOnTerm(metricsServer, time.Duration(10)*time.Second)
 
 	go func() {
 		klog.Infof("Listening on %s", addr)

--- a/pkg/cert/cert_watcher.go
+++ b/pkg/cert/cert_watcher.go
@@ -1,0 +1,152 @@
+package cert
+
+/*
+  Provides base implementation to monitor a certificate for pending expiration, and trigger an
+  implementation-defined method to renew it.
+
+  Almost all of the actual lgoic below is copied from k8s.io/client-go/util/certificate/certificate_manager.go
+  which implements the "watching for expiry" feature.
+  The difference here is that our Reload method can do arbitrary task to obtain a new cert,
+  where as the k8s certificate_manager only performs CSR request towards k8s API.
+*/
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+	"sync"
+	"time"
+)
+
+type CertWatcher interface {
+	Current() *tls.Certificate
+	Start()
+	Stop()
+}
+
+type CertProvider interface {
+	Load() (*tls.Certificate, error)
+}
+
+type certWatcher struct {
+	certAccessLock sync.RWMutex
+	cert           *tls.Certificate
+
+	lock    sync.Mutex
+	stopCh  chan struct{}
+	stopped bool
+
+	provider CertProvider
+}
+
+func newCertWatcher(provider CertProvider) (*certWatcher, error) {
+	c := &certWatcher{
+		stopCh:   make(chan struct{}),
+		provider: provider,
+	}
+
+	if ok, _ := c.reload(); !ok {
+		return nil, errors.New("Configured certificate does not exist")
+	}
+
+	return c, nil
+}
+
+func (c *certWatcher) Current() *tls.Certificate {
+	c.certAccessLock.RLock()
+	defer c.certAccessLock.RUnlock()
+	if c.cert != nil && c.cert.Leaf != nil && time.Now().After(c.cert.Leaf.NotAfter) {
+		klog.V(2).Infof("Current certificate is expired.")
+		return nil
+	}
+	return c.cert
+}
+
+func (c *certWatcher) reload() (bool, error) {
+	newCert, err := c.provider.Load()
+	if err != nil {
+		klog.Errorf("reload failed: %v", err)
+		return false, nil
+	}
+
+	if newCert.Leaf != nil && time.Now().After(newCert.Leaf.NotAfter) {
+		klog.Errorf("reload failed, provided certificate is expired")
+		return false, nil
+	}
+
+	c.certAccessLock.Lock()
+	defer c.certAccessLock.Unlock()
+
+	klog.Infof("Updating certificate, expires at %v", newCert.Leaf.NotAfter)
+	c.cert = newCert
+
+	return true, nil
+}
+
+func (c *certWatcher) Start() {
+	go wait.Until(func() {
+		deadline := c.nextRotationDeadline()
+		if sleepInterval := deadline.Sub(time.Now()); sleepInterval > 0 {
+			klog.V(2).Infof("Waiting %v for next certificate rotation", sleepInterval)
+
+			timer := time.NewTimer(sleepInterval)
+			defer timer.Stop()
+
+			select {
+			case <-timer.C:
+				// unblock when deadline expires
+				klog.V(2).Infof("Reloading certificate")
+			}
+		}
+
+		backoff := wait.Backoff{
+			Duration: 2 * time.Second,
+			Factor:   2,
+			Jitter:   0.1,
+			Steps:    5,
+		}
+		if err := wait.ExponentialBackoff(backoff, c.reload); err != nil {
+			utilruntime.HandleError(fmt.Errorf("Reached backoff limit, still unable to rotate certs: %v", err))
+			wait.PollInfinite(32*time.Second, c.reload)
+		}
+	}, time.Second, c.stopCh)
+}
+
+func (c *certWatcher) Stop() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.stopped {
+		return
+	}
+	close(c.stopCh)
+	c.stopped = true
+}
+
+// nextRotationDeadline returns a value for the threshold at which the
+// current certificate should be rotated, 80%+/-10% of the expiration of the
+// certificate.
+func (c *certWatcher) nextRotationDeadline() time.Time {
+	c.certAccessLock.RLock()
+	defer c.certAccessLock.RUnlock()
+	notAfter := c.cert.Leaf.NotAfter
+	totalDuration := float64(notAfter.Sub(c.cert.Leaf.NotBefore))
+	deadline := c.cert.Leaf.NotBefore.Add(jitteryDuration(totalDuration))
+
+	klog.V(2).Infof("Certificate expiration is %v, rotation deadline is %v", notAfter, deadline)
+	return deadline
+}
+
+// jitteryDuration uses some jitter to set the rotation threshold so each node
+// will rotate at approximately 70-90% of the total lifetime of the
+// certificate.  With jitter, if a number of nodes are added to a cluster at
+// approximately the same time (such as cluster creation time), they won't all
+// try to rotate certificates at the same time for the rest of the life of the
+// cluster.
+//
+// This function is represented as a variable to allow replacement during testing.
+var jitteryDuration = func(totalDuration float64) time.Duration {
+	return wait.Jitter(time.Duration(totalDuration), 0.2) - time.Duration(totalDuration*0.3)
+}

--- a/pkg/cert/cert_watcher_file.go
+++ b/pkg/cert/cert_watcher_file.go
@@ -1,0 +1,47 @@
+package cert
+
+/*
+  Provides certificate watcher which reads the certificate from a file, both on startup and on renewal.
+  The update must be done externally.
+*/
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"k8s.io/klog"
+)
+
+type fileCertWatcher struct {
+	certFile string
+	keyFile  string
+}
+
+// Monitors cert/keyfile for changes and attempts to reload if updated.
+func NewFileCertWatcher(certFile, keyFile string) (CertWatcher, error) {
+	fc := &fileCertWatcher{
+		certFile: certFile,
+		keyFile:  keyFile,
+	}
+
+	return newCertWatcher(fc)
+}
+
+func (fc *fileCertWatcher) Load() (*tls.Certificate, error) {
+	klog.Infof("Loading cert from file %s", fc.certFile)
+	newCert, err := tls.LoadX509KeyPair(fc.certFile, fc.keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// LoadX509KeyPair does this but does not provide the data, unfortunately.. so some duplicate work..
+	certs, err := x509.ParseCertificates(newCert.Certificate[0])
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse certificate data: %v", err)
+	}
+	newCert.Leaf = certs[0]
+
+	klog.Infof("Loaded keypair from %s, %s", fc.certFile, fc.keyFile)
+
+	return &newCert, nil
+}

--- a/pkg/cert/cert_watcher_store.go
+++ b/pkg/cert/cert_watcher_store.go
@@ -1,0 +1,43 @@
+package cert
+
+/*
+  Provides certificate watcher which reads the certificate from the CertificateStore (k8s secret),
+  both on startup and on renewal.
+  The update must be done externally.
+
+  Suitable for use with OpenShift's "service serving certificate" feature (using the
+  service.beta.openshift.io/serving-cert-secret-name annotation to provide certificates to services).
+*/
+
+import (
+	"crypto/tls"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/certificate"
+)
+
+type storeCertWatcher struct {
+	certificateStore certificate.Store
+}
+
+func NewSecretStoreCertWatcher(kubeClient clientset.Interface, namespace, secretName string) (CertWatcher, error) {
+	certificateStore := NewSecretCertStore(
+		namespace,
+		secretName,
+		kubeClient,
+	)
+
+	sc := &storeCertWatcher{
+		certificateStore: certificateStore,
+	}
+
+	return newCertWatcher(sc)
+}
+
+func (sc *storeCertWatcher) Load() (*tls.Certificate, error) {
+	newCert, err := sc.certificateStore.Current()
+	if err != nil {
+		return nil, err
+	}
+
+	return newCert, nil
+}


### PR DESCRIPTION
After following the guide on https://www.openshift.com/blog/fine-grained-iam-roles-for-openshift-applications to setup AWS integration in our OpenShift cluster, we noticed after a few weeks that the newly created CSRs where not automatically approved. Not sure if that is done on other k8s distributions, but not on OC (4.5). 
An alternative solution of handling the TLS certificates is to use what OC calls "Service serving certificates", i.e. let OC generate & renew certificates, and provide them via a secret. Some more details on that particular problem here, but not really relevant for the PR: https://github.com/sabre1041/openshift-aws-iam-webhook-integration/issues/3

This change adds support for the `--external-tls-renewal` flag which will make the k8s Secret "readonly", i.e only read but never update it. Instead of having the k8s go-client `certificate_manager.Manager` renew it via CSR API, it will just try to re-read it from the secret when it is is nearing expiration time.

The actual implementation is pretty much a copy of the `certificate_manager.Manager` impl, but this allows delegation to a arbitrary method to "Load" it. Unfortunately the original impl does not permit re-use, so had to copy a bit..
As for reading the secret, it uses the existing SecretCertStore impl.

In addition, this also adds reload support for when using external file rather than secrets (`--in-cluster=false`). Actually started that way, with the secret mounted on a volume, before I decided to just read it from the secret from the code. And with the abstraction it was quite straightforward anyway.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
