### PR TITLE
README: add documentation for running containers as non-root

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Or for Kubernetes 1.14+
 [1]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html
 [2]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html
 
+### Usage with non-root container user
+
+When running a container with a non-root user, you need to give the container access to the token file by setting the `fsGroup` field in the `securityContext` object.
+
 ## Usage
 
 ```


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-eks-pod-identity-webhook/pull/86

*Description of changes:*
Document how non-root containers can access the token file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
