### PR TITLE
Add a debug handler to list cache contents and log mutation decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Usage of amazon-eks-pod-identity-webhook:
       --annotation-prefix string         The Service Account annotation to look for (default "eks.amazonaws.com")
       --aws-default-region string        If set, AWS_DEFAULT_REGION and AWS_REGION will be set to this value in mutated containers
       --in-cluster                       Use in-cluster authentication and certificate request API (default true)
+      --enable-debugging-handlers        Enable debugging handlers on the metrics port (http). Currently /debug/alpha/cache is supported (default false) [ALPHA]
       --kube-api string                  (out-of-cluster) The url to the API server
       --kubeconfig string                (out-of-cluster) Absolute path to the API server kubeconfig file
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)

--- a/pkg/cache/debug/debug.go
+++ b/pkg/cache/debug/debug.go
@@ -1,0 +1,20 @@
+package debug
+
+import (
+	"fmt"
+	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/cache"
+	"k8s.io/klog"
+	"net/http"
+)
+
+type Dumper struct {
+	Cache cache.ServiceAccountCache
+}
+
+func (c *Dumper) Handle(w http.ResponseWriter, r *http.Request) {
+	res := c.Cache.ToJSON()
+	if _, err := w.Write([]byte(res)); err != nil {
+		klog.Errorf("Can't dump cache contents: %v", err)
+		http.Error(w, fmt.Sprintf("could not write response: %v", err), http.StatusInternalServerError)
+	}
+}

--- a/pkg/cache/debug/debug_test.go
+++ b/pkg/cache/debug/debug_test.go
@@ -1,0 +1,99 @@
+package debug
+
+import (
+	"encoding/json"
+	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/cache"
+	"io"
+	"io/ioutil"
+	corev1 "k8s.io/api/core/v1"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+)
+
+// generateServiceAccount generates n service accounts with arbitrary contents
+func generateServiceAccounts(n int) []*corev1.ServiceAccount {
+	if n <= 0 {
+		return []*corev1.ServiceAccount{}
+	}
+	accounts := make([]*corev1.ServiceAccount, n)
+	for i := 0; i < n; i++ {
+		testServiceAccount := &corev1.ServiceAccount{}
+		testServiceAccount.Name = "test-sa-" + strconv.Itoa(i)
+		testServiceAccount.Namespace = "default"
+		testServiceAccount.Annotations = map[string]string{
+			"eks.amazonaws.com/role-arn": "arn:aws:iam::111122223333:role/s3-reader-" + strconv.Itoa(i),
+			"eks.amazonaws.com/audience": "sts.amazonaws.com",
+		}
+		accounts[i] = testServiceAccount
+	}
+	return accounts
+}
+
+func TestLister(t *testing.T) {
+	fakeSAList := generateServiceAccounts(50000)
+	emptySAList := []*corev1.ServiceAccount{}
+	debugger := Dumper{
+		Cache: cache.NewFakeServiceAccountCache(fakeSAList...),
+	}
+	ts := httptest.NewServer(
+		http.HandlerFunc(debugger.Handle),
+	)
+	defer ts.Close()
+
+	cases := []struct {
+		caseName         string
+		Cache            cache.ServiceAccountCache
+		inputContentType string
+		expectedLength   int
+	}{
+		{
+			"content-type xml",
+			cache.NewFakeServiceAccountCache(fakeSAList...),
+			"application/xml",
+			50000,
+		},
+		{
+			"content-type json",
+			cache.NewFakeServiceAccountCache(fakeSAList...),
+			"application/json",
+			50000,
+		},
+		{
+			"empty cache",
+			cache.NewFakeServiceAccountCache(emptySAList...),
+			"application/json",
+			0,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.caseName, func(t *testing.T) {
+			debugger.Cache = c.Cache
+			var buf io.Reader
+			resp, err := http.Post(ts.URL, c.inputContentType, buf)
+			if err != nil {
+				t.Errorf("Failed to make request: %v", err)
+				return
+			}
+			responseBytes, err := ioutil.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if err != nil {
+				t.Errorf("Failed to read response: %v", err)
+				return
+			}
+			m := map[string]cache.CacheResponse{}
+			err = json.Unmarshal(responseBytes, &m)
+			if err != nil {
+				t.Errorf("Failed to unmarshal: %v", err)
+				return
+			}
+			t.Log(len(m))
+			if len(m) != c.expectedLength {
+				t.Errorf("Failed to receive cache contents")
+			}
+
+		})
+	}
+}

--- a/pkg/cache/fake.go
+++ b/pkg/cache/fake.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"encoding/json"
 	"k8s.io/api/core/v1"
 	"strconv"
 	"sync"
@@ -62,4 +63,14 @@ func (f *FakeServiceAccountCache) Pop(name, namespace string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	delete(f.cache, namespace+"/"+name)
+}
+
+func (f *FakeServiceAccountCache) ToJSON() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	contents, err := json.MarshalIndent(f.cache, "", " ")
+	if err != nil {
+		return ""
+	}
+	return string(contents)
 }

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -144,6 +144,19 @@ type patchOperation struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
+func logContext(podName, podGenerateName, serviceAccountName, namespace string) string {
+	name := podName
+	if len(podName) == 0 {
+		name = podGenerateName
+	}
+	return fmt.Sprintf("Pod=%s, " +
+		"ServiceAccount=%s, " +
+		"Namespace=%s",
+		name,
+		serviceAccountName,
+		namespace)
+}
+
 func (m *Modifier) addEnvToContainer(container *corev1.Container, tokenFilePath, roleName string, podSettings *podUpdateSettings) {
 	// return if this is a named skipped container
 	if _, ok := podSettings.skipContainers[container.Name]; ok {
@@ -360,6 +373,8 @@ func (m *Modifier) MutatePod(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResp
 
 	// determine whether to perform mutation
 	if podRole == "" {
+		klog.V(3).Infof("Pod was not mutated. %s",
+			logContext(pod.Name, pod.GenerateName, pod.Spec.ServiceAccountName, pod.Namespace))
 		return &v1beta1.AdmissionResponse{
 			Allowed: true,
 		}
@@ -375,6 +390,8 @@ func (m *Modifier) MutatePod(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResp
 		}
 	}
 
+	klog.V(3).Infof("Pod was mutated. %s",
+		logContext(pod.Name, pod.GenerateName, pod.Spec.ServiceAccountName, pod.Namespace))
 	return &v1beta1.AdmissionResponse{
 		Allowed: true,
 		Patch:   patchBytes,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added a debug endpoint to debug application state. Similar to the kubelet flag --enable-debugging-handlers.

Pre-1.16, audit logs do not have mutation decision annotated. If appropriate logging level is enabled, mutation decision logs could be of help for those clusters.

Issues such as https://github.com/aws/amazon-eks-pod-identity-webhook/issues/83 would be easier to debug

Open to suggestions/feedback on this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
