### PR TITLE
Allow specifying baseArn to prepend to role names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Usage of amazon-eks-pod-identity-webhook:
       --alsologtostderr                  log to standard error as well as files
       --annotation-prefix string         The Service Account annotation to look for (default "eks.amazonaws.com")
       --aws-default-region string        If set, AWS_DEFAULT_REGION and AWS_REGION will be set to this value in mutated containers
+      --base-arn string                  The base arn to use if a non fully qualified role is detected
       --in-cluster                       Use in-cluster authentication and certificate request API (default true)
       --enable-debugging-handlers        Enable debugging handlers on the metrics port (http). Currently /debug/alpha/cache is supported (default false) [ALPHA]
       --kube-api string                  (out-of-cluster) The url to the API server

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func main() {
 	// annotation/volume configurations
 	annotationPrefix := flag.String("annotation-prefix", "eks.amazonaws.com", "The Service Account annotation to look for")
 	audience := flag.String("token-audience", "sts.amazonaws.com", "The default audience for tokens. Can be overridden by annotation")
+	baseArn := flag.String("base-arn", "", "The base arn to use if a non fully qualified role is detected")
 	mountPath := flag.String("token-mount-path", "/var/run/secrets/eks.amazonaws.com/serviceaccount", "The path to mount tokens")
 	tokenExpiration := flag.Int64("token-expiration", 86400, "The token expiration")
 	region := flag.String("aws-default-region", "", "If set, AWS_DEFAULT_REGION and AWS_REGION will be set to this value in mutated containers")
@@ -112,6 +113,7 @@ func main() {
 		handler.WithServiceAccountCache(saCache),
 		handler.WithRegion(*region),
 		handler.WithRegionalSTS(*regionalSTS),
+		handler.WithBaseArn(*baseArn),
 	)
 
 	addr := fmt.Sprintf(":%d", *port)

--- a/pkg/handler/handler_pod_test.go
+++ b/pkg/handler/handler_pod_test.go
@@ -48,6 +48,7 @@ var (
 	handlerExpirationAnnotation = "testing.eks.amazonaws.com/handler/expiration"
 	handlerRegionAnnotation     = "testing.eks.amazonaws.com/handler/region"
 	handlerSTSAnnotation        = "testing.eks.amazonaws.com/handler/injectSTS"
+	handlerBaseArnAnnotation    = "testing.eks.amazonaws.com/handler/baseArn"
 )
 
 func getModifierFromPod(pod corev1.Pod) (*Modifier, error) {
@@ -72,6 +73,9 @@ func getModifierFromPod(pod corev1.Pod) (*Modifier, error) {
 			return nil, err
 		}
 		modifiers = append(modifiers, WithRegionalSTS(value))
+	}
+	if baseArnAnnotation, ok := pod.Annotations[handlerBaseArnAnnotation]; ok {
+		modifiers = append(modifiers, WithBaseArn(baseArnAnnotation))
 	}
 	return NewModifier(modifiers...), nil
 }

--- a/pkg/handler/testdata/rawPodNoBaseArn.pod.yaml
+++ b/pkg/handler/testdata/rawPodNoBaseArn.pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/handler/baseArn: 'arn:aws:iam::111122223333:role/'
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes/0","value":{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default
+  volumes:
+    - name: my-volume


### PR DESCRIPTION
*Description of changes:*
This PR introduces the ability to specify a baseArn to prepend to role names when we detect that the arn passed to the `eks.amazonaws.com/role-arn` annotation is not fully qualified. 

Our use case is that we have different clusters that run in different AWS accounts. This will allow us to use the same manifest to deploy to these different clusters and allow each pod to assume the correct IAM role local to their account.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
