### PR TITLE
Add annotation option for token expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ This webhook is for mutating pods that will require AWS IAM access.
         # optional: When set to "true", adds AWS_STS_REGIONAL_ENDPOINTS env var
         #   to containers
         eks.amazonaws.com/sts-regional-endpoints: "true"
+        # optional: Defaults to 86400 for expirationSeconds if not set
+        #   Note: This value can be overwritten if specified in the pod 
+        #         annotation as shown in the next step.
+        eks.amazonaws.com/token-expiration: "86400"
     ```
 4. All new pod pods launched using this Service Account will be modified to use
    IAM for pods. Below is an example pod spec with the environment variables and
@@ -65,8 +69,11 @@ This webhook is for mutating pods that will require AWS IAM access.
       namespace: default
       annotations:
         # optional: A comma-separated list of initContainers and container names
-        #   to skip adding volumes and environemnt variables
+        #   to skip adding volumes and environment variables
         eks.amazonaws.com/skip-containers: "init-first,sidecar"
+        # optional: Defaults to 86400, or value specified in ServiceAccount
+        #   annotation as shown in previous step, for expirationSeconds if not set
+        eks.amazonaws.com/token-expiration: "86400"
     spec:
       serviceAccountName: my-serviceaccount
       initContainers:

--- a/pkg/annotations.go
+++ b/pkg/annotations.go
@@ -21,6 +21,8 @@ const (
 	RoleARNAnnotation = "role-arn"
 	// A true/false value to add AWS_STS_REGIONAL_ENDPOINTS. Overrides any setting on the webhook
 	UseRegionalSTSAnnotation = "sts-regional-endpoints"
+	// Expiration in seconds for serviceAccountToken annotation
+	TokenExpirationAnnotation = "token-expiration"
 
 	// A comma-separated list of container names to skip adding environment variables and volumes to. Applies to `initContainers` and `containers`
 	SkipContainersAnnotation = "skip-containers"

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -14,6 +14,7 @@ func TestSaCache(t *testing.T) {
 	testSA.Annotations = map[string]string{
 		"eks.amazonaws.com/role-arn":               roleArn,
 		"eks.amazonaws.com/sts-regional-endpoints": "true",
+		"eks.amazonaws.com/token-expiration":       "3600",
 	}
 
 	cache := &serviceAccountCache{
@@ -22,15 +23,15 @@ func TestSaCache(t *testing.T) {
 		annotationPrefix: "eks.amazonaws.com",
 	}
 
-	role, aud, useRegionalSTS := cache.Get("default", "default")
+	role, aud, useRegionalSTS, tokenExpiration := cache.Get("default", "default")
 
 	if role != "" || aud != "" {
-		t.Errorf("Expected role and aud to be empty, got %s, %s, %t", role, aud, useRegionalSTS)
+		t.Errorf("Expected role and aud to be empty, got %s, %s, %t, %d", role, aud, useRegionalSTS, tokenExpiration)
 	}
 
 	cache.addSA(testSA)
 
-	role, aud, useRegionalSTS = cache.Get("default", "default")
+	role, aud, useRegionalSTS, tokenExpiration = cache.Get("default", "default")
 	if role != roleArn {
 		t.Errorf("Expected role to be %s, got %s", roleArn, role)
 	}
@@ -39,5 +40,8 @@ func TestSaCache(t *testing.T) {
 	}
 	if useRegionalSTS {
 		t.Error("Expected regional STS to be true, got false")
+	}
+	if tokenExpiration != 3600 {
+		t.Errorf("Expected token expiration to be 3600, got %d", tokenExpiration)
 	}
 }

--- a/pkg/cache/fake.go
+++ b/pkg/cache/fake.go
@@ -5,6 +5,8 @@ import (
 	"k8s.io/api/core/v1"
 	"strconv"
 	"sync"
+
+	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
 )
 
 // FakeServiceAccountCache is a goroutine safe cache for testing
@@ -25,8 +27,13 @@ func NewFakeServiceAccountCache(accounts ...*v1.ServiceAccount) *FakeServiceAcco
 		}
 		regionalSTSstr, _ := sa.Annotations["eks.amazonaws.com/sts-regional-endpoints"]
 		regionalSTS, _ := strconv.ParseBool(regionalSTSstr)
+		tokenExpirationStr, _ := sa.Annotations["eks.amazonaws.com/token-expiration"]
+		tokenExpiration, err := strconv.ParseInt(tokenExpirationStr, 10, 64)
+		if err != nil {
+			tokenExpiration = pkg.DefaultTokenExpiration // Otherwise default would be 0
+		}
 
-		c.Add(sa.Name, sa.Namespace, arn, audience, regionalSTS)
+		c.Add(sa.Name, sa.Namespace, arn, audience, regionalSTS, tokenExpiration)
 	}
 	return c
 }
@@ -37,24 +44,25 @@ var _ ServiceAccountCache = &FakeServiceAccountCache{}
 func (f *FakeServiceAccountCache) Start() {}
 
 // Get gets a service account from the cache
-func (f *FakeServiceAccountCache) Get(name, namespace string) (role, aud string, useRegionalSTS bool) {
+func (f *FakeServiceAccountCache) Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	resp, ok := f.cache[namespace+"/"+name]
 	if !ok {
-		return "", "", false
+		return "", "", false, pkg.DefaultTokenExpiration
 	}
-	return resp.RoleARN, resp.Audience, resp.UseRegionalSTS
+	return resp.RoleARN, resp.Audience, resp.UseRegionalSTS, resp.TokenExpiration
 }
 
 // Add adds a cache entry
-func (f *FakeServiceAccountCache) Add(name, namespace, role, aud string, regionalSTS bool) {
+func (f *FakeServiceAccountCache) Add(name, namespace, role, aud string, regionalSTS bool, tokenExpiration int64) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.cache[namespace+"/"+name] = &CacheResponse{
-		RoleARN:        role,
-		Audience:       aud,
-		UseRegionalSTS: regionalSTS,
+		RoleARN:         role,
+		Audience:        aud,
+		UseRegionalSTS:  regionalSTS,
+		TokenExpiration: tokenExpiration,
 	}
 }
 

--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -1,0 +1,23 @@
+/*
+  Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  A copy of the License is located at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  or in the "license" file accompanying this file. This file is distributed
+  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing
+  permissions and limitations under the License.
+*/
+package pkg
+
+const (
+	// Default token expiration in seconds if none is defined,
+	// which is 24hrs as that is max for EKS
+	DefaultTokenExpiration = int64(86400)
+	// 1hr is min for kube-apiserver
+	MinTokenExpiration = int64(3600)
+)

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -95,7 +95,7 @@ var rawPodWithoutVolume = []byte(`
 }
 `)
 
-var validPatchIfNoVolumesPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
+var validPatchIfNoVolumesPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":3600,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 
 var validHandlerResponse = &v1beta1.AdmissionResponse{
 	UID:       "918ef1dc-928f-4525-99ef-988389f263c3",
@@ -143,6 +143,7 @@ func TestModifierHandler(t *testing.T) {
 	testServiceAccount.Namespace = "default"
 	testServiceAccount.Annotations = map[string]string{
 		"eks.amazonaws.com/role-arn": "arn:aws:iam::111122223333:role/s3-reader",
+		"eks.amazonaws.com/token-expiration": "3600",
 	}
 
 	modifier := NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount)))

--- a/pkg/handler/testdata/rawPodHasAll.pod.yaml
+++ b/pkg/handler/testdata/rawPodHasAll.pod.yaml
@@ -8,7 +8,8 @@ metadata:
     testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
     testing.eks.amazonaws.com/handler/injectSTS: "true"
     testing.eks.amazonaws.com/handler/region: "cn-north-1"
-    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_REGION","value":"cn-northwest-1"},{"name":"AWS_STS_REGIONAL_ENDPOINTS","value":"regional"},{"name":"AWS_ROLE_ARN","value":"arn:aws-cn:iam::111122223333:role/s3-reader"}],"resources":{}}]}]'
+    testing.eks.amazonaws.com/handler/expiration: "3600"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":3600,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_REGION","value":"cn-northwest-1"},{"name":"AWS_STS_REGIONAL_ENDPOINTS","value":"regional"},{"name":"AWS_ROLE_ARN","value":"arn:aws-cn:iam::111122223333:role/s3-reader"}],"resources":{}}]}]'
 spec:
   containers:
   - env:

--- a/pkg/handler/testdata/rawPodHasTokenExpiration.pod.yaml
+++ b/pkg/handler/testdata/rawPodHasTokenExpiration.pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws-cn:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/handler/injectSTS: "true"
+    testing.eks.amazonaws.com/handler/region: "cn-north-1"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":3600,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_REGION","value":"cn-northwest-1"},{"name":"AWS_STS_REGIONAL_ENDPOINTS","value":"regional"},{"name":"AWS_ROLE_ARN","value":"arn:aws-cn:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+    # Pod Annotation
+    eks.amazonaws.com/token-expiration: "3600"
+spec:
+  containers:
+  - env:
+    - name: AWS_REGION
+      value: cn-northwest-1
+    - name: AWS_STS_REGIONAL_ENDPOINTS
+      value: regional
+    image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default

--- a/pkg/handler/testdata/rawPodMinTokenExpiration.pod.yaml
+++ b/pkg/handler/testdata/rawPodMinTokenExpiration.pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws-cn:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/handler/injectSTS: "true"
+    testing.eks.amazonaws.com/handler/region: "cn-north-1"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":3600,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_REGION","value":"cn-northwest-1"},{"name":"AWS_STS_REGIONAL_ENDPOINTS","value":"regional"},{"name":"AWS_ROLE_ARN","value":"arn:aws-cn:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+    # Pod Annotation
+    eks.amazonaws.com/token-expiration: "0"
+spec:
+  containers:
+  - env:
+    - name: AWS_REGION
+      value: cn-northwest-1
+    - name: AWS_STS_REGIONAL_ENDPOINTS
+      value: regional
+    image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default

--- a/pkg/validation.go
+++ b/pkg/validation.go
@@ -1,0 +1,22 @@
+/*
+  Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  A copy of the License is located at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  or in the "license" file accompanying this file. This file is distributed
+  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing
+  permissions and limitations under the License.
+*/
+package pkg
+
+func ValidateMinTokenExpiration(expiration int64) (int64) {
+	if expiration < MinTokenExpiration {
+		return MinTokenExpiration
+	}
+	return expiration
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added annotation capability for both ServiceAccount and Pod to enable option to modify the expirationSeconds for the token, just like it is available as a flag to the binary. 

Note that the annotation in the pod would take precedence over the annotation in the service account to allow the ability to have certain pods where a customer wants to use a different expiration in seconds. Mentioned this distinction in the README as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
