### PR TITLE
Add DNSName to SAN for go1.15 CN deprecation and add signer name to CSRs

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,15 +149,13 @@ func main() {
 	if *inCluster {
 		csr := &x509.CertificateRequest{
 			Subject: pkix.Name{CommonName: fmt.Sprintf("%s.%s.svc", *serviceName, *namespaceName)},
+			DNSNames: []string{
+				fmt.Sprintf("%s", *serviceName),
+				fmt.Sprintf("%s.%s", *serviceName, *namespaceName),
+				fmt.Sprintf("%s.%s.svc", *serviceName, *namespaceName),
+				fmt.Sprintf("%s.%s.svc.cluster.local", *serviceName, *namespaceName),
+			},
 			/*
-				// TODO: EKS Signer only allows SANS for ec2-approved domains, once this is fixed
-				// add additional domains and IPs
-				DNSNames: []string{
-					fmt.Sprintf("%s", *serviceName),
-					fmt.Sprintf("%s.%s", *serviceName, *namespaceName),
-					fmt.Sprintf("%s.%s.svc", *serviceName, *namespaceName),
-					fmt.Sprintf("%s.%s.svc.cluster.local", *serviceName, *namespaceName),
-				},
 				// TODO: SANIPs for service IP, but not pod IP
 				//IPAddresses: nil,
 			*/

--- a/pkg/cert/request.go
+++ b/pkg/cert/request.go
@@ -65,6 +65,7 @@ func NewServerCertificateManager(kubeClient clientset.Interface, namespace, secr
 			// authenticate itself to a TLS client.
 			certificates.UsageServerAuth,
 		},
+		SignerName:          certificates.LegacyUnknownSignerName,
 		CertificateStore:    certificateStore,
 		CertificateRotation: certificateRotation,
 	})


### PR DESCRIPTION
*Issue #, if available:*
89

*Description of changes:*

- [Go 1.15 deprecated the use of the CommonName field](https://golang.org/doc/go1.15#commonname) as a HostName when no SANs are present.[Kubernetes v1.19](https://github.com/kubernetes/kubernetes/pull/93264) is now built with 1.15 and so has this deprecation in place

- Signer Name can not be empty. Consumers of client-go's certificate manager has to pass in a valid signer as this [PR](https://github.com/kubernetes/kubernetes/pull/88246/files) does on this [line](https://github.com/munnerz/kubernetes/blob/d5dae048983cd299cdce9d2703f564bf4bd246ee/pkg/kubelet/certificate/kubelet.go#L110) 


Without the signer name, CSRs were not admitted into the system with
```
I1230 01:57:37.015897       1 main.go:207] Listening on :443
E1230 01:57:37.026648       1 certificate_manager.go:434] Failed while requesting a signed certificate from the master: cannot create certificate signing request: CertificateSigningRequest.certificates.k8s.io "csr-smrgk" is invalid: spec.signerName: Required value: signerName must be provided
E1230 01:57:39.217589       1 certificate_manager.go:434] Failed while requesting a signed certificate from the master: cannot create certificate signing request: CertificateSigningRequest.certificates.k8s.io "csr-ctttm" is invalid:
spec.signerName: Required value: signerName must be provided
```

After the right signer name was added
```
NAME        AGE   SIGNERNAME                     REQUESTOR                                            CONDITION
csr-6hl7m   5s    kubernetes.io/legacy-unknown   system:serviceaccount:default:pod-identity-webhook   Approved,Issued
```

Before adding DNS names
```
W1230 03:30:01.175496       1 dispatcher.go:170] Failed calling webhook, failing open pod-identity-webhook.amazonaws.com: failed calling webhook "pod-identity-webhook.amazonaws.com": Post "https://pod-identity-webhook.default.svc:443/mutate?timeout=30s": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
```

After adding DNS names, pod-identity-webhook functions as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
