### PR TITLE
Allow specifying baseArn to prefix to role names when necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Usage of amazon-eks-pod-identity-webhook:
       --alsologtostderr                  log to standard error as well as files
       --annotation-prefix string         The Service Account annotation to look for (default "eks.amazonaws.com")
       --aws-default-region string        If set, AWS_DEFAULT_REGION and AWS_REGION will be set to this value in mutated containers
+      --base-arn string                  The base arn to use if a non fully qualified role is detected
       --in-cluster                       Use in-cluster authentication and certificate request API (default true)
       --enable-debugging-handlers        Enable debugging handlers on the metrics port (http). Currently /debug/alpha/cache is supported (default false) [ALPHA]
       --kube-api string                  (out-of-cluster) The url to the API server

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 	// annotation/volume configurations
 	annotationPrefix := flag.String("annotation-prefix", "eks.amazonaws.com", "The Service Account annotation to look for")
 	audience := flag.String("token-audience", "sts.amazonaws.com", "The default audience for tokens. Can be overridden by annotation")
+	baseArn := flag.String("base-arn", "", "The base arn to use if a non fully qualified role is detected")
 	mountPath := flag.String("token-mount-path", "/var/run/secrets/eks.amazonaws.com/serviceaccount", "The path to mount tokens")
 	tokenExpiration := flag.Int64("token-expiration", pkg.DefaultTokenExpiration, "The token expiration")
 	region := flag.String("aws-default-region", "", "If set, AWS_DEFAULT_REGION and AWS_REGION will be set to this value in mutated containers")
@@ -115,6 +116,7 @@ func main() {
 		handler.WithServiceAccountCache(saCache),
 		handler.WithRegion(*region),
 		handler.WithRegionalSTS(*regionalSTS),
+		handler.WithBaseArn(*baseArn),
 	)
 
 	addr := fmt.Sprintf(":%d", *port)

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -75,6 +75,8 @@ var (
 	deserializer  = codecs.UniversalDeserializer()
 )
 
+const arnPrefix = "arn:"
+
 // ModifierOpt is an option type for setting up a Modifier
 type ModifierOpt func(*Modifier)
 
@@ -103,6 +105,11 @@ func WithRegionalSTS(enabled bool) ModifierOpt {
 	return func(m *Modifier) { m.RegionalSTSEndpoint = enabled }
 }
 
+// WithBaseArn sets the baseArn to use if we detect role name is not fully qualified
+func WithBaseArn(baseArn string) ModifierOpt {
+	return func(m *Modifier) { m.BaseArn = baseArn }
+}
+
 // WithAnnotationDomain adds an annotation domain
 func WithAnnotationDomain(domain string) ModifierOpt {
 	return func(m *Modifier) { m.AnnotationDomain = domain }
@@ -128,6 +135,7 @@ func NewModifier(opts ...ModifierOpt) *Modifier {
 // Modifier holds configuration values for pod modifications
 type Modifier struct {
 	AnnotationDomain    string
+	BaseArn             string
 	Expiration          int64
 	MountPath           string
 	Region              string
@@ -156,7 +164,7 @@ func logContext(podName, podGenerateName, serviceAccountName, namespace string) 
 		namespace)
 }
 
-func (m *Modifier) addEnvToContainer(container *corev1.Container, tokenFilePath, roleName string, podSettings *podUpdateSettings) bool {
+func (m *Modifier) addEnvToContainer(container *corev1.Container, tokenFilePath, fullRoleArn string, podSettings *podUpdateSettings) bool {
 	// return if this is a named skipped container
 	if _, ok := podSettings.skipContainers[container.Name]; ok {
 		klog.V(4).Infof("Container %s was annotated to be skipped", container.Name)
@@ -226,7 +234,7 @@ func (m *Modifier) addEnvToContainer(container *corev1.Container, tokenFilePath,
 	if !reservedKeysDefined {
 		env = append(env, corev1.EnvVar{
 			Name:  "AWS_ROLE_ARN",
-			Value: roleName,
+			Value: fullRoleArn,
 		})
 
 		env = append(env, corev1.EnvVar{
@@ -259,6 +267,14 @@ func (m *Modifier) addEnvToContainer(container *corev1.Container, tokenFilePath,
 	return changed
 }
 
+func (m *Modifier) fullRoleArn(arn string) string {
+	if strings.HasPrefix(arn, arnPrefix) {
+		return arn
+	}
+
+	return fmt.Sprintf("%s%s", m.BaseArn, arn)
+}
+
 func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string, regionalSTS bool, tokenExpiration int64) ([]patchOperation, bool) {
 	updateSettings := newPodUpdateSettings(m.AnnotationDomain, pod, regionalSTS)
 
@@ -273,17 +289,19 @@ func (m *Modifier) updatePodSpec(pod *corev1.Pod, roleName, audience string, reg
 		tokenFilePath = "C:" + strings.Replace(tokenFilePath, `/`, `\`, -1)
 	}
 
+	fullRoleArn := m.fullRoleArn(roleName)
+
 	var changed bool
 	var initContainers = []corev1.Container{}
 	for i := range pod.Spec.InitContainers {
 		container := pod.Spec.InitContainers[i]
-		changed = m.addEnvToContainer(&container, tokenFilePath, roleName, updateSettings)
+		changed = m.addEnvToContainer(&container, tokenFilePath, fullRoleArn, updateSettings)
 		initContainers = append(initContainers, container)
 	}
 	var containers = []corev1.Container{}
 	for i := range pod.Spec.Containers {
 		container := pod.Spec.Containers[i]
-		changed = m.addEnvToContainer(&container, tokenFilePath, roleName, updateSettings)
+		changed = m.addEnvToContainer(&container, tokenFilePath, fullRoleArn, updateSettings)
 		containers = append(containers, container)
 	}
 

--- a/pkg/handler/handler_pod_test.go
+++ b/pkg/handler/handler_pod_test.go
@@ -49,6 +49,7 @@ var (
 	handlerExpirationAnnotation = "testing.eks.amazonaws.com/handler/expiration"
 	handlerRegionAnnotation     = "testing.eks.amazonaws.com/handler/region"
 	handlerSTSAnnotation        = "testing.eks.amazonaws.com/handler/injectSTS"
+	handlerBaseArnAnnotation    = "testing.eks.amazonaws.com/handler/baseArn"
 )
 
 func getModifierFromPod(pod corev1.Pod) (*Modifier, error) {
@@ -73,6 +74,9 @@ func getModifierFromPod(pod corev1.Pod) (*Modifier, error) {
 			return nil, err
 		}
 		modifiers = append(modifiers, WithRegionalSTS(value))
+	}
+	if baseArnAnnotation, ok := pod.Annotations[handlerBaseArnAnnotation]; ok {
+		modifiers = append(modifiers, WithBaseArn(baseArnAnnotation))
 	}
 	return NewModifier(modifiers...), nil
 }

--- a/pkg/handler/testdata/rawPodNoBaseArn.pod.yaml
+++ b/pkg/handler/testdata/rawPodNoBaseArn.pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  annotations:
+    testing.eks.amazonaws.com/handler/baseArn: 'arn:aws:iam::111122223333:role/'
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes/0","value":{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default
+  volumes:
+    - name: my-volume


### PR DESCRIPTION
If the role-arn specified in the eks.amazonaws.com/role-arn is not
fully qualified, prepend it with a default base Arn.
