### PR TITLE
Refactor service account cache to accept informer arg and unit test it 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,17 @@
+name: test
+
+on: pull_request
+jobs:
+  test:
+    # this is to prevent the job to run at forked projects
+    if: github.repository == 'aws/amazon-eks-pod-identity-webhook'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test
+      run: go test ./...

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ almost all cases, unless the STS regional endpoint is [disabled in your
 account](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html).
 
 You can also enable this per-service account with the annotation
-`eks.amazonaws.com/sts-regional-endpoint` set to `"true"`.
+`eks.amazonaws.com/sts-regional-endpoints` set to `"true"`.
 
 ## Container Images
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.4.0
 	gopkg.in/square/go-jose.v2 v2.5.1
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.18.9-rc.0

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -108,17 +108,17 @@ func (c *serviceAccountCache) addSA(sa *v1.ServiceAccount) {
 		}
 
 		resp.UseRegionalSTS = c.defaultRegionalSTS
-		if disableRegionalStr, ok := sa.Annotations[c.annotationPrefix+"/"+pkg.UseRegionalSTSAnnotation]; ok {
-			disableRegional, err := strconv.ParseBool(disableRegionalStr)
+		if useRegionalStr, ok := sa.Annotations[c.annotationPrefix+"/"+pkg.UseRegionalSTSAnnotation]; ok {
+			useRegional, err := strconv.ParseBool(useRegionalStr)
 			if err != nil {
 				klog.V(4).Infof("Ignoring service account %s/%s invalid value for disable-regional-sts annotation", sa.Namespace, sa.Name)
 			} else {
-				resp.UseRegionalSTS = !disableRegional
+				resp.UseRegionalSTS = useRegional
 			}
 		}
 
 		resp.TokenExpiration = c.defaultTokenExpiration
-		if tokenExpirationStr, ok := sa.Annotations[c.annotationPrefix + "/" + pkg.TokenExpirationAnnotation]; ok {
+		if tokenExpirationStr, ok := sa.Annotations[c.annotationPrefix+"/"+pkg.TokenExpirationAnnotation]; ok {
 			if tokenExpiration, err := strconv.ParseInt(tokenExpirationStr, 10, 64); err != nil {
 				klog.V(4).Infof("Found invalid value for token expiration, using %d seconds as default: %v", resp.TokenExpiration, err)
 			} else {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -177,6 +177,7 @@ func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenEx
 func (c *serviceAccountCache) start(stop chan struct{}) {
 
 	if !cache.WaitForCacheSync(stop, c.hasSynced) {
+		klog.Fatal("unable to sync serviceaccount cache!")
 		return
 	}
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -20,13 +20,11 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
@@ -40,7 +38,7 @@ type CacheResponse struct {
 }
 
 type ServiceAccountCache interface {
-	Start()
+	Start(stop chan struct{})
 	Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64)
 	// ToJSON returns cache contents as JSON string
 	ToJSON() string
@@ -49,8 +47,7 @@ type ServiceAccountCache interface {
 type serviceAccountCache struct {
 	mu                     sync.RWMutex // guards cache
 	cache                  map[string]*CacheResponse
-	store                  cache.Store
-	controller             cache.Controller
+	hasSynced              cache.InformerSynced
 	clientset              kubernetes.Interface
 	annotationPrefix       string
 	defaultAudience        string
@@ -136,26 +133,17 @@ func (c *serviceAccountCache) set(name, namespace string, resp *CacheResponse) {
 	c.cache[namespace+"/"+name] = resp
 }
 
-func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenExpiration int64, clientset kubernetes.Interface) ServiceAccountCache {
+func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenExpiration int64, informer coreinformers.ServiceAccountInformer) ServiceAccountCache {
 	c := &serviceAccountCache{
 		cache:                  map[string]*CacheResponse{},
 		defaultAudience:        defaultAudience,
 		annotationPrefix:       prefix,
 		defaultRegionalSTS:     defaultRegionalSTS,
 		defaultTokenExpiration: defaultTokenExpiration,
+		hasSynced:              informer.Informer().HasSynced,
 	}
 
-	saListWatcher := cache.NewListWatchFromClient(
-		clientset.CoreV1().RESTClient(),
-		"serviceaccounts",
-		v1.NamespaceAll,
-		fields.Everything(),
-	)
-
-	c.store, c.controller = cache.NewInformer(
-		saListWatcher,
-		&v1.ServiceAccount{},
-		time.Second*60,
+	informer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				sa := obj.(*v1.ServiceAccount)
@@ -186,24 +174,15 @@ func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenEx
 	return c
 }
 
-func (c *serviceAccountCache) start() {
-	// Populate the cache
-	err := cache.ListAll(c.store, labels.Everything(), func(obj interface{}) {
-		sa := obj.(*v1.ServiceAccount)
-		c.addSA(sa)
-	})
-	if err != nil {
-		klog.Errorf("Error fetching service accounts: %v", err.Error())
+func (c *serviceAccountCache) start(stop chan struct{}) {
+
+	if !cache.WaitForCacheSync(stop, c.hasSynced) {
 		return
 	}
 
-	stop := make(chan struct{})
-	defer close(stop)
-	go c.controller.Run(stop)
-	// Wait forever
-	select {}
+	<-stop
 }
 
-func (c *serviceAccountCache) Start() {
-	go c.start()
+func (c *serviceAccountCache) Start(stop chan struct{}) {
+	go c.start(stop)
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,10 +1,16 @@
 package cache
 
 import (
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestSaCache(t *testing.T) {
@@ -41,25 +47,120 @@ func TestSaCache(t *testing.T) {
 }
 
 func TestNonRegionalSTS(t *testing.T) {
-	testSA := &v1.ServiceAccount{}
-	testSA.Name = "default"
-	testSA.Namespace = "default"
+	trueStr := "true"
+	falseStr := "false"
+	emptyStr := ""
 	roleArn := "arn:aws:iam::111122223333:role/s3-reader"
-	testSA.Annotations = map[string]string{
-		"eks.amazonaws.com/role-arn":               roleArn,
-		"eks.amazonaws.com/sts-regional-endpoints": "false",
-		"eks.amazonaws.com/token-expiration":       "3600",
+	audience := "sts.amazonaws.com"
+	tokenExpiration := "3600"
+	testCases := []struct {
+		name                   string
+		regionalSTSAnnotation  *string
+		defaultRegionalSTS     bool
+		expectedUseRegionalSts bool
+	}{
+		{
+			name:                   "annotation true, default false, expect true",
+			regionalSTSAnnotation:  &trueStr,
+			defaultRegionalSTS:     false,
+			expectedUseRegionalSts: true,
+		},
+		{
+			name:                   "annotation false, default false, expect false",
+			regionalSTSAnnotation:  &falseStr,
+			defaultRegionalSTS:     false,
+			expectedUseRegionalSts: false,
+		},
+		{
+			name:                   "annotation empty, default false, expect false",
+			regionalSTSAnnotation:  &emptyStr,
+			defaultRegionalSTS:     false,
+			expectedUseRegionalSts: false,
+		},
+		{
+			name:                   "no annotation, default false, expect false",
+			regionalSTSAnnotation:  nil,
+			defaultRegionalSTS:     false,
+			expectedUseRegionalSts: false,
+		},
+		{
+			name:                   "annotation true, default true, expect true",
+			regionalSTSAnnotation:  &trueStr,
+			defaultRegionalSTS:     true,
+			expectedUseRegionalSts: true,
+		},
+		{
+			name:                   "annotation false, default true, expect false",
+			regionalSTSAnnotation:  &falseStr,
+			defaultRegionalSTS:     true,
+			expectedUseRegionalSts: false,
+		},
+		{
+			name:                   "annotation empty, default true, expect true",
+			regionalSTSAnnotation:  &emptyStr,
+			defaultRegionalSTS:     true,
+			expectedUseRegionalSts: true,
+		},
+		{
+			name:                   "no annotation, default true, expect true",
+			regionalSTSAnnotation:  nil,
+			defaultRegionalSTS:     true,
+			expectedUseRegionalSts: true,
+		},
 	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testSA := &v1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"eks.amazonaws.com/role-arn":         roleArn,
+						"eks.amazonaws.com/token-expiration": tokenExpiration,
+					},
+				},
+			}
+			if tc.regionalSTSAnnotation != nil {
+				testSA.ObjectMeta.Annotations["eks.amazonaws.com/sts-regional-endpoints"] = *tc.regionalSTSAnnotation
+			}
 
-	cache := &serviceAccountCache{
-		cache:            map[string]*CacheResponse{},
-		defaultAudience:  "sts.amazonaws.com",
-		annotationPrefix: "eks.amazonaws.com",
+			fakeClient := fake.NewSimpleClientset(testSA)
+			informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+			informer := informerFactory.Core().V1().ServiceAccounts()
+
+			cache := New(audience, "eks.amazonaws.com", tc.defaultRegionalSTS, 86400, informer)
+			stop := make(chan struct{})
+			informerFactory.Start(stop)
+			cache.Start(stop)
+			defer close(stop)
+
+			err := wait.ExponentialBackoff(wait.Backoff{Duration: 10 * time.Millisecond, Factor: 1.0, Steps: 3}, func() (bool, error) {
+				return len(fakeClient.Actions()) != 0, nil
+			})
+			if err != nil {
+				t.Fatalf("informer never called client: %v", err)
+			}
+
+			err = wait.ExponentialBackoff(wait.Backoff{Duration: 10 * time.Millisecond, Factor: 1.0, Steps: 3}, func() (bool, error) {
+				return len(cache.(*serviceAccountCache).cache) != 0, nil
+			})
+			if err != nil {
+				t.Fatalf("cache never called addSA: %v", err)
+			}
+
+			gotRoleArn, gotAudience, useRegionalSTS, gotTokenExpiration := cache.Get("default", "default")
+			if gotRoleArn != roleArn {
+				t.Errorf("got roleArn %v, expected %v", gotRoleArn, roleArn)
+			}
+			if gotAudience != audience {
+				t.Errorf("got audience %v, expected %v", gotAudience, audience)
+			}
+			if strconv.Itoa(int(gotTokenExpiration)) != tokenExpiration {
+				t.Errorf("got token expiration %v, expected %v", gotTokenExpiration, tokenExpiration)
+			}
+			if useRegionalSTS != tc.expectedUseRegionalSts {
+				t.Errorf("got use regional STS %v, expected %v", useRegionalSTS, tc.expectedUseRegionalSts)
+			}
+		})
 	}
-
-	cache.addSA(testSA)
-
-	_, _, useRegionalSTS, _ := cache.Get("default", "default")
-
-	assert.False(t, useRegionalSTS, "Expected regional STS to be false, got true")
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -129,6 +129,7 @@ func TestNonRegionalSTS(t *testing.T) {
 			informer := informerFactory.Core().V1().ServiceAccounts()
 
 			cache := New(audience, "eks.amazonaws.com", tc.defaultRegionalSTS, 86400, informer)
+			cache.(*serviceAccountCache).hasSynced = func() bool { return true }
 			stop := make(chan struct{})
 			informerFactory.Start(stop)
 			cache.Start(stop)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3,7 +3,8 @@ package cache
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestSaCache(t *testing.T) {
@@ -32,16 +33,33 @@ func TestSaCache(t *testing.T) {
 	cache.addSA(testSA)
 
 	role, aud, useRegionalSTS, tokenExpiration = cache.Get("default", "default")
-	if role != roleArn {
-		t.Errorf("Expected role to be %s, got %s", roleArn, role)
+
+	assert.Equal(t, roleArn, role, "Expected role to be %s, got %s", roleArn, role)
+	assert.Equal(t, "sts.amazonaws.com", aud, "Expected aud to be sts.amzonaws.com, got %s", aud)
+	assert.True(t, useRegionalSTS, "Expected regional STS to be true, got false")
+	assert.Equal(t, int64(3600), tokenExpiration, "Expected token expiration to be 3600, got %d", tokenExpiration)
+}
+
+func TestNonRegionalSTS(t *testing.T) {
+	testSA := &v1.ServiceAccount{}
+	testSA.Name = "default"
+	testSA.Namespace = "default"
+	roleArn := "arn:aws:iam::111122223333:role/s3-reader"
+	testSA.Annotations = map[string]string{
+		"eks.amazonaws.com/role-arn":               roleArn,
+		"eks.amazonaws.com/sts-regional-endpoints": "false",
+		"eks.amazonaws.com/token-expiration":       "3600",
 	}
-	if aud != "sts.amazonaws.com" {
-		t.Errorf("Expected aud to be sts.amzonaws.com, got %s", aud)
+
+	cache := &serviceAccountCache{
+		cache:            map[string]*CacheResponse{},
+		defaultAudience:  "sts.amazonaws.com",
+		annotationPrefix: "eks.amazonaws.com",
 	}
-	if useRegionalSTS {
-		t.Error("Expected regional STS to be true, got false")
-	}
-	if tokenExpiration != 3600 {
-		t.Errorf("Expected token expiration to be 3600, got %d", tokenExpiration)
-	}
+
+	cache.addSA(testSA)
+
+	_, _, useRegionalSTS, _ := cache.Get("default", "default")
+
+	assert.False(t, useRegionalSTS, "Expected regional STS to be false, got true")
 }

--- a/pkg/cache/fake.go
+++ b/pkg/cache/fake.go
@@ -41,7 +41,7 @@ func NewFakeServiceAccountCache(accounts ...*v1.ServiceAccount) *FakeServiceAcco
 var _ ServiceAccountCache = &FakeServiceAccountCache{}
 
 // Start does nothing
-func (f *FakeServiceAccountCache) Start() {}
+func (f *FakeServiceAccountCache) Start(chan struct{}) {}
 
 // Get gets a service account from the cache
 func (f *FakeServiceAccountCache) Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

test more cases. https://github.com/aws/amazon-eks-pod-identity-webhook/pull/116#discussion_r636566019

Instead of calling addSA directly, use a fake client/informer. This is a closer approximation of reality, because we want to test that: given a serviceaccount already exists , and we start the controller, does it pick it up.

since this is a big refactor I also intend to test it end to end when I have time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
