### PR TITLE
add metrics for knowing adoption

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -64,6 +64,10 @@ var webhookUsage = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help: "Indicator to know pod identity webhook is used",
 })
 
+func init() {
+	prometheus.MustRegister(webhookUsage)
+}
+
 func (c *serviceAccountCache) Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64) {
 	klog.V(5).Infof("Fetching sa %s/%s from cache", namespace, name)
 	resp := c.get(name, namespace)
@@ -151,6 +155,7 @@ func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenEx
 		defaultRegionalSTS:     defaultRegionalSTS,
 		defaultTokenExpiration: defaultTokenExpiration,
 		hasSynced:              informer.Informer().HasSynced,
+		webhookUsage:           webhookUsage,
 	}
 
 	informer.Informer().AddEventHandler(

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
-	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -54,7 +53,6 @@ type serviceAccountCache struct {
 	defaultAudience        string
 	defaultRegionalSTS     bool
 	defaultTokenExpiration int64
-	saCount                prometheus.Gauge
 }
 
 func (c *serviceAccountCache) Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64) {
@@ -124,7 +122,6 @@ func (c *serviceAccountCache) addSA(sa *v1.ServiceAccount) {
 				resp.TokenExpiration = pkg.ValidateMinTokenExpiration(tokenExpiration)
 			}
 		}
-		c.saCount.Inc()
 	}
 	klog.V(5).Infof("Adding sa %s/%s to cache", sa.Name, sa.Namespace)
 	c.set(sa.Name, sa.Namespace, resp)
@@ -137,13 +134,6 @@ func (c *serviceAccountCache) set(name, namespace string, resp *CacheResponse) {
 }
 
 func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenExpiration int64, informer coreinformers.ServiceAccountInformer) ServiceAccountCache {
-	saCount := prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "sa_count",
-			Help: "Counter for number of service accounts annotated with pod identity webhook",
-		},
-	)
-	prometheus.MustRegister(saCount)
 	c := &serviceAccountCache{
 		cache:                  map[string]*CacheResponse{},
 		defaultAudience:        defaultAudience,
@@ -151,7 +141,6 @@ func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenEx
 		defaultRegionalSTS:     defaultRegionalSTS,
 		defaultTokenExpiration: defaultTokenExpiration,
 		hasSynced:              informer.Informer().HasSynced,
-		saCount:                saCount,
 	}
 
 	informer.Informer().AddEventHandler(
@@ -174,10 +163,6 @@ func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenEx
 						return
 					}
 				}
-				if _, ok := sa.Annotations[c.annotationPrefix+"/"+pkg.RoleARNAnnotation]; ok {
-					c.saCount.Dec()
-				}
-				c.saCount.Dec()
 				c.pop(sa.Name, sa.Namespace)
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
@@ -186,7 +171,6 @@ func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenEx
 			},
 		},
 	)
-
 	return c
 }
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -57,17 +57,6 @@ type serviceAccountCache struct {
 	saCount                prometheus.Gauge
 }
 
-var saCount = prometheus.NewGauge(
-	prometheus.GaugeOpts{
-		Name: "sa_count",
-		Help: "Counter for number of service accounts annotated with pod identity webhook",
-	},
-)
-
-func init() {
-	prometheus.MustRegister(saCount)
-}
-
 func (c *serviceAccountCache) Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64) {
 	klog.V(5).Infof("Fetching sa %s/%s from cache", namespace, name)
 	resp := c.get(name, namespace)
@@ -148,6 +137,13 @@ func (c *serviceAccountCache) set(name, namespace string, resp *CacheResponse) {
 }
 
 func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenExpiration int64, informer coreinformers.ServiceAccountInformer) ServiceAccountCache {
+	saCount := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "sa_count",
+			Help: "Counter for number of service accounts annotated with pod identity webhook",
+		},
+	)
+	prometheus.MustRegister(saCount)
 	c := &serviceAccountCache{
 		cache:                  map[string]*CacheResponse{},
 		defaultAudience:        defaultAudience,

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -57,6 +57,17 @@ type serviceAccountCache struct {
 	saCount                prometheus.Gauge
 }
 
+var saCount = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Name: "sa_count",
+		Help: "Counter for number of service accounts annotated with pod identity webhook",
+	},
+)
+
+func init() {
+	prometheus.MustRegister(saCount)
+}
+
 func (c *serviceAccountCache) Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64) {
 	klog.V(5).Infof("Fetching sa %s/%s from cache", namespace, name)
 	resp := c.get(name, namespace)
@@ -137,13 +148,6 @@ func (c *serviceAccountCache) set(name, namespace string, resp *CacheResponse) {
 }
 
 func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenExpiration int64, informer coreinformers.ServiceAccountInformer) ServiceAccountCache {
-	saCount := prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "sa_count",
-			Help: "Counter for number of service accounts annotated with pod identity webhook",
-		},
-	)
-	prometheus.MustRegister(saCount)
 	c := &serviceAccountCache{
 		cache:                  map[string]*CacheResponse{},
 		defaultAudience:        defaultAudience,

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -57,8 +57,11 @@ type serviceAccountCache struct {
 	webhookUsage           prometheus.Gauge
 }
 
-// We need a way to know if the webhook is used in a cluster to drive changes.
-// We could perform more interesting operations by knowing how many service accounts are being annotated.
+// We need a way to know if the webhook is used in a cluster.
+// There are multiple ways to achieve that.
+// We could keep track of the number of annotated service accounts, however we need some additional logic and refactoring to make sure the metric doesn't grow unbounded due to resync.
+// We could also track the number of pod mutations, but that won't show us the usage until pods churn.
+// This is a minimal way to know the usage. We can add more metrics for annotated service accounts and pod mutations as need arises.
 var webhookUsage = prometheus.NewGauge(prometheus.GaugeOpts{
 	Name: "pod_identity_webhook_used",
 	Help: "Indicator to know pod identity webhook is used",

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +29,7 @@ func TestSaCache(t *testing.T) {
 		cache:            map[string]*CacheResponse{},
 		defaultAudience:  "sts.amazonaws.com",
 		annotationPrefix: "eks.amazonaws.com",
+		webhookUsage:     prometheus.NewGauge(prometheus.GaugeOpts{}),
 	}
 
 	role, aud, useRegionalSTS, tokenExpiration := cache.Get("default", "default")

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +28,6 @@ func TestSaCache(t *testing.T) {
 		cache:            map[string]*CacheResponse{},
 		defaultAudience:  "sts.amazonaws.com",
 		annotationPrefix: "eks.amazonaws.com",
-		saCount:          prometheus.NewGauge(prometheus.GaugeOpts{}),
 	}
 
 	role, aud, useRegionalSTS, tokenExpiration := cache.Get("default", "default")

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +29,7 @@ func TestSaCache(t *testing.T) {
 		cache:            map[string]*CacheResponse{},
 		defaultAudience:  "sts.amazonaws.com",
 		annotationPrefix: "eks.amazonaws.com",
+		saCount:          prometheus.NewGauge(prometheus.GaugeOpts{}),
 	}
 
 	role, aud, useRegionalSTS, tokenExpiration := cache.Get("default", "default")

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/cache"
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -40,15 +39,6 @@ import (
 type podUpdateSettings struct {
 	skipContainers map[string]bool
 	useRegionalSTS bool
-}
-
-var mutations = prometheus.NewCounter(prometheus.CounterOpts{
-	Name: "mutations",
-	Help: "Count of mutations on the pods",
-})
-
-func init() {
-	prometheus.MustRegister(mutations)
 }
 
 // newPodUpdateSettings returns the update settings for a particular pod
@@ -426,7 +416,6 @@ func (m *Modifier) MutatePod(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResp
 
 	// TODO: klog structured logging can make this better
 	if changed {
-		mutations.Inc()
 		klog.V(3).Infof("Pod was mutated. %s",
 			logContext(pod.Name, pod.GenerateName, pod.Spec.ServiceAccountName, pod.Namespace))
 	} else {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While handling the infrastructure for a cluster, we need a way to know which clusters are using the webhook to drive changes that change default values through the infra.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
