### PR TITLE
Update instructions for self-hosted cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Container images for amazon-eks-pod-identity-webhook can be found on [Docker Hub
 You can use the provided configuration files in the `deploy` directory, along with the provided `Makefile`
 
 ```
-make cluster-up IMAGE=amazon/amazon-eks-pod-identity-webhook:2db5e53
+make cluster-up IMAGE=amazon/amazon-eks-pod-identity-webhook:latest
 ```
 
 This will:

--- a/SELF_HOSTED_SETUP.md
+++ b/SELF_HOSTED_SETUP.md
@@ -65,7 +65,7 @@ Lets create these:
 ```bash
 cat <<EOF > discovery.json
 {
-    "issuer": "https://$ISSUER_HOSTPATH/",
+    "issuer": "https://$ISSUER_HOSTPATH",
     "jwks_uri": "https://$ISSUER_HOSTPATH/keys.json",
     "authorization_endpoint": "urn:kubernetes:programmatic_authorization",
     "response_types_supported": [
@@ -161,6 +161,11 @@ yourself, you can use any audience you'd like as long as the webhook's flag
 From here, you can mostly follow the process in the [EKS
 documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
 and substitute the cluster issuer with `https://$ISSUER_HOSTPATH`.
+
+## Deploying the webhook
+
+Follow the steps in the [In-cluster installation](https://github.com/aws/amazon-eks-pod-identity-webhook#in-cluster) section to launch the webhook
+and its required resources in the cluster.
 
 ## Troubleshooting
 


### PR DESCRIPTION
This commit adds the following changes for the self hosted cluster doc:
* Removes trailing slash from issuer uri in discovery.json. If the
--oidc-issuer-url does not have a trailing slash then apiserver will error
due to mismatched issuer URLs.
* Update image tag in Readme to latest. The current image tag when used
generates a cert for the webhook that uses CN instead of SAN. API Server
returns an error for that. The latest image tag generates a cert with SAN.
* Add a link to the in-cluster installation section.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
