### PR TITLE
Fix Prometheus scraper config in k8s service

### DIFF
--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -4,12 +4,16 @@ metadata:
   name: pod-identity-webhook
   namespace: default
   annotations:
-    prometheus.io/port: "443"
-    prometheus.io/scheme: "https"
+    prometheus.io/port: "9999"
+    prometheus.io/scheme: "http"
     prometheus.io/scrape: "true"
 spec:
   ports:
-  - port: 443
-    targetPort: 443
+    - name: webhook
+      port: 443
+      targetPort: 443
+    - name: metrics
+      port: 9999
+      targetPort: 9999
   selector:
     app: pod-identity-webhook


### PR DESCRIPTION
Exposed the metrics port in the k8s service and configured Prometheus annotations to use the metrics port instead of the webhook one

Fix: #136

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
