### PR TITLE
add cert manager deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,16 +199,16 @@ Container images for amazon-eks-pod-identity-webhook can be found on [Docker Hub
 
 ### In-cluster
 
-You can use the provided configuration files in the `deploy` directory, along with the provided `Makefile`
+You can use the provided configuration files in the `deploy` directory, along with the provided `Makefile`. You must install a cert-manager as it is a pre-requisite for below deployments. (See [cert-manager installation](https://cert-manager.io/docs/installation/)) 
 
 ```
 make cluster-up IMAGE=amazon/amazon-eks-pod-identity-webhook:latest
 ```
 
 This will:
-* Create a service account, role, cluster-role, role-binding, and cluster-role-binding that will the deployment requires
-* Create the deployment, service, and mutating webhook in the cluster
-* Approve the CSR that the deployment created for its TLS serving certificate
+* Create a service account, role, cluster-role, role-binding, and cluster-role-binding that the deployment requires
+* Create the deployment, service, ClusterIssuer, certificate, and mutating webhook in the cluster
+* Use `in-cluster=false` so that now webhook can reload certs when they are renewed
 
 For self-hosted API server configuration, see see [SELF_HOSTED_SETUP.md](/SELF_HOSTED_SETUP.md)
 

--- a/README.md
+++ b/README.md
@@ -197,9 +197,13 @@ Container images for amazon-eks-pod-identity-webhook can be found on [Docker Hub
 
 ## Installation
 
+### Pre-requisites
+
+You must install cert-manager as it is a pre-requisite for below deployments. (See [cert-manager installation](https://cert-manager.io/docs/installation/))
+
 ### In-cluster
 
-You can use the provided configuration files in the `deploy` directory, along with the provided `Makefile`. You must install a cert-manager as it is a pre-requisite for below deployments. (See [cert-manager installation](https://cert-manager.io/docs/installation/)) 
+You can use the provided configuration files in the `deploy` directory, along with the provided `Makefile`.
 
 ```
 make cluster-up IMAGE=amazon/amazon-eks-pod-identity-webhook:latest
@@ -208,7 +212,7 @@ make cluster-up IMAGE=amazon/amazon-eks-pod-identity-webhook:latest
 This will:
 * Create a service account, role, cluster-role, role-binding, and cluster-role-binding that the deployment requires
 * Create the deployment, service, ClusterIssuer, certificate, and mutating webhook in the cluster
-* Use `in-cluster=false` so that now webhook can reload certs when they are renewed
+* Use `in-cluster=false` so that the webhook reloads certificates from the filesystem rather than creating CSRs to request certificates (using CSRs is now deprecated and will not work versions later than v0.3.0).
 
 For self-hosted API server configuration, see see [SELF_HOSTED_SETUP.md](/SELF_HOSTED_SETUP.md)
 
@@ -225,3 +229,4 @@ See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 ## License
 Apache 2.0 - Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 See [LICENSE](LICENSE)
+

--- a/deploy/deployment-base.yaml
+++ b/deploy/deployment-base.yaml
@@ -20,17 +20,44 @@ spec:
         imagePullPolicy: Always
         command:
         - /webhook
-        - --in-cluster
+        - --in-cluster=false
         - --namespace=default
         - --service-name=pod-identity-webhook
-        - --tls-secret=pod-identity-webhook
         - --annotation-prefix=eks.amazonaws.com
         - --token-audience=sts.amazonaws.com
         - --logtostderr
         volumeMounts:
-        - name: webhook-certs
-          mountPath: /var/run/app/certs
-          readOnly: false
+        - name: cert
+          mountPath: "/etc/webhook/certs"
+          readOnly: true
       volumes:
-      - name: webhook-certs
-        emptyDir: {}
+      - name: cert
+        secret:
+          secretName: pod-identity-webhook-cert
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: pod-identity-webhook
+  namespace: default
+spec:
+  secretName: pod-identity-webhook-cert
+  commonName: "pod-identity-webhook.default.svc"
+  dnsNames:
+  - "pod-identity-webhook"
+  - "pod-identity-webhook.default"
+  - "pod-identity-webhook.default.svc"
+  - "pod-identity-webhook.default.svc.local"
+  isCA: true
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer

--- a/deploy/mutatingwebhook.yaml
+++ b/deploy/mutatingwebhook.yaml
@@ -1,20 +1,22 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: pod-identity-webhook
   namespace: default
+  annotations:
+    cert-manager.io/inject-ca-from: default/pod-identity-webhook
 webhooks:
 - name: pod-identity-webhook.amazonaws.com
   failurePolicy: Ignore
-  sideEffects: None
   clientConfig:
     service:
       name: pod-identity-webhook
       namespace: default
       path: "/mutate"
-    caBundle: ${CA_BUNDLE}
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
     apiVersions: ["v1"]
     resources: ["pods"]
+  sideEffects: None
+  admissionReviewVersions: ["v1beta1"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* updates to
* deploy/deployment-base.yaml
  - setting in-cluster=false
  - update volumeMounts paths
  - add cert-manager deployment
     - cert-manager.io/v1 ClusterIssuer
     - cert-manager.io/v1 Certificate
* deploy/mutatingwebhook.yaml
  - add annotations to replace caBundle


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
