### PR TITLE
Add option to pass configmap with mapping between SA and IAM role

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 	// in-cluster TLS options
 	inCluster := flag.Bool("in-cluster", true, "Use in-cluster authentication and certificate request API")
 	serviceName := flag.String("service-name", "pod-identity-webhook", "(in-cluster) The service name fronting this webhook")
-	namespaceName := flag.String("namespace", "eks", "(in-cluster) The namespace name this webhook and the tls secret resides in")
+	namespaceName := flag.String("namespace", "eks", "(in-cluster) The namespace name this webhook, the TLS secret, and configmap resides in")
 	tlsSecret := flag.String("tls-secret", "pod-identity-webhook", "(in-cluster) The secret name for storing the TLS serving cert")
 
 	// annotation/volume configurations
@@ -69,7 +69,7 @@ func main() {
 	tokenExpiration := flag.Int64("token-expiration", pkg.DefaultTokenExpiration, "The token expiration")
 	region := flag.String("aws-default-region", "", "If set, AWS_DEFAULT_REGION and AWS_REGION will be set to this value in mutated containers")
 	regionalSTS := flag.Bool("sts-regional-endpoint", false, "Whether to inject the AWS_STS_REGIONAL_ENDPOINTS=regional env var in mutated pods. Defaults to `false`.")
-	watchConfigMap := flag.Bool("watch-config-map", false, "Whether to watch the pod-identity-webhook ConfigMap for additional Service Accounts. Defaults to `false`.")
+	watchConfigMap := flag.Bool("watch-config-map", false, "Enables watching serviceaccounts that are configured through the pod-identity-webhook configmap instead of using annotations")
 
 	version := flag.Bool("version", false, "Display the version and exit")
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
@@ -47,7 +48,8 @@ type ServiceAccountCache interface {
 
 type serviceAccountCache struct {
 	mu                     sync.RWMutex // guards cache
-	cache                  map[string]*CacheResponse
+	saCache                map[string]*CacheResponse
+	cmCache                map[string]*CacheResponse
 	hasSynced              cache.InformerSynced
 	clientset              kubernetes.Interface
 	annotationPrefix       string
@@ -73,36 +75,61 @@ func init() {
 
 func (c *serviceAccountCache) Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64) {
 	klog.V(5).Infof("Fetching sa %s/%s from cache", namespace, name)
-	resp := c.get(name, namespace)
-	if resp == nil {
-		klog.V(4).Infof("Service account %s/%s not found in cache", namespace, name)
-		return "", "", false, pkg.DefaultTokenExpiration
+	{
+		resp := c.getSA(name, namespace)
+		if resp != nil && resp.RoleARN != "" {
+			return resp.RoleARN, resp.Audience, resp.UseRegionalSTS, resp.TokenExpiration
+		}
 	}
-	return resp.RoleARN, resp.Audience, resp.UseRegionalSTS, resp.TokenExpiration
+	{
+		resp := c.getCM(name, namespace)
+		if resp != nil {
+			return resp.RoleARN, resp.Audience, resp.UseRegionalSTS, resp.TokenExpiration
+		}
+	}
+	klog.V(5).Infof("Service account %s/%s not found in cache", namespace, name)
+	return "", "", false, pkg.DefaultTokenExpiration
 }
 
-func (c *serviceAccountCache) get(name, namespace string) *CacheResponse {
+func (c *serviceAccountCache) getSA(name, namespace string) *CacheResponse {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	resp, ok := c.cache[namespace+"/"+name]
+	resp, ok := c.saCache[namespace+"/"+name]
 	if !ok {
 		return nil
 	}
 	return resp
 }
 
-func (c *serviceAccountCache) pop(name, namespace string) {
-	klog.V(5).Infof("Removing sa %s/%s from cache", namespace, name)
+func (c *serviceAccountCache) getCM(name, namespace string) *CacheResponse {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	resp, ok := c.cmCache[namespace+"/"+name]
+	if !ok {
+		return nil
+	}
+	return resp
+}
+
+func (c *serviceAccountCache) popSA(name, namespace string) {
+	klog.V(5).Infof("Removing SA %s/%s from SA cache", namespace, name)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.cache, namespace+"/"+name)
+	delete(c.saCache, namespace+"/"+name)
+}
+
+func (c *serviceAccountCache) popCM(name, namespace string) {
+	klog.V(5).Infof("Removing SA %s/%s from CM cache", namespace, name)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.cmCache, namespace+"/"+name)
 }
 
 // Log cache contents for debugginqg
 func (c *serviceAccountCache) ToJSON() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	contents, err := json.MarshalIndent(c.cache, "", " ")
+	contents, err := json.MarshalIndent(c.saCache, "", " ")
 	if err != nil {
 		klog.Errorf("Json marshal error: %v", err.Error())
 		return ""
@@ -140,28 +167,43 @@ func (c *serviceAccountCache) addSA(sa *v1.ServiceAccount) {
 		}
 		c.webhookUsage.Set(1)
 	}
-	klog.V(5).Infof("Adding sa %s/%s to cache: %+v", sa.Name, sa.Namespace, resp)
-	c.set(sa.Name, sa.Namespace, resp)
+	c.setSA(sa.Name, sa.Namespace, resp)
 }
 
-func (c *serviceAccountCache) set(name, namespace string, resp *CacheResponse) {
+func (c *serviceAccountCache) setSA(name, namespace string, resp *CacheResponse) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.cache[namespace+"/"+name] = resp
+	klog.V(5).Infof("Adding SA %s/%s to SA cache: %+v", namespace, name, resp)
+	c.saCache[namespace+"/"+name] = resp
 }
 
-func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenExpiration int64, informer coreinformers.ServiceAccountInformer) ServiceAccountCache {
+func (c *serviceAccountCache) setCM(name, namespace string, resp *CacheResponse) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	klog.V(5).Infof("Adding SA %s/%s to CM cache: %+v", namespace, name, resp)
+	c.cmCache[namespace+"/"+name] = resp
+}
+
+func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenExpiration int64, saInformer coreinformers.ServiceAccountInformer, cmInformer coreinformers.ConfigMapInformer) ServiceAccountCache {
+	hasSynced := func() bool {
+		if cmInformer != nil {
+			return saInformer.Informer().HasSynced() && cmInformer.Informer().HasSynced()
+		} else {
+			return saInformer.Informer().HasSynced()
+		}
+	}
 	c := &serviceAccountCache{
-		cache:                  map[string]*CacheResponse{},
+		saCache:                map[string]*CacheResponse{},
+		cmCache:                map[string]*CacheResponse{},
 		defaultAudience:        defaultAudience,
 		annotationPrefix:       prefix,
 		defaultRegionalSTS:     defaultRegionalSTS,
 		defaultTokenExpiration: defaultTokenExpiration,
-		hasSynced:              informer.Informer().HasSynced,
+		hasSynced:              hasSynced,
 		webhookUsage:           webhookUsage,
 	}
 
-	informer.Informer().AddEventHandler(
+	saInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				sa := obj.(*v1.ServiceAccount)
@@ -181,7 +223,7 @@ func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenEx
 						return
 					}
 				}
-				c.pop(sa.Name, sa.Namespace)
+				c.popSA(sa.Name, sa.Namespace)
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				sa := newObj.(*v1.ServiceAccount)
@@ -189,7 +231,60 @@ func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenEx
 			},
 		},
 	)
+	if cmInformer != nil {
+		cmInformer.Informer().AddEventHandler(
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					err := c.populateCacheFromCM(nil, obj.(*v1.ConfigMap))
+					if err != nil {
+						utilruntime.HandleError(err)
+					}
+				},
+				UpdateFunc: func(oldObj, newObj interface{}) {
+					err := c.populateCacheFromCM(oldObj.(*v1.ConfigMap), newObj.(*v1.ConfigMap))
+					if err != nil {
+						utilruntime.HandleError(err)
+					}
+				},
+			},
+		)
+	}
 	return c
+}
+
+func (c *serviceAccountCache) populateCacheFromCM(oldCM, newCM *v1.ConfigMap) error {
+	if newCM.Name != "pod-identity-webhook" {
+		return nil
+	}
+	newConfig := newCM.Data["config"]
+	sas := make(map[string]*CacheResponse)
+	err := json.Unmarshal([]byte(newConfig), &sas)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal new config %q: %v", newConfig, err)
+	}
+	for key, resp := range sas {
+		parts := strings.Split(key, "/")
+		if resp.TokenExpiration == 0 {
+			resp.TokenExpiration = c.defaultTokenExpiration
+		}
+		c.setCM(parts[1], parts[0], resp)
+	}
+
+	if oldCM != nil {
+		oldConfig := oldCM.Data["config"]
+		oldCache := make(map[string]*CacheResponse)
+		err := json.Unmarshal([]byte(oldConfig), &oldCache)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal old config %q: %v", oldConfig, err)
+		}
+		for key := range oldCache {
+			if _, found := sas[key]; !found {
+				parts := strings.Split(key, "/")
+				c.popCM(parts[1], parts[0])
+			}
+		}
+	}
+	return nil
 }
 
 func (c *serviceAccountCache) start(stop chan struct{}) {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -73,6 +73,9 @@ func init() {
 	prometheus.MustRegister(webhookUsage)
 }
 
+// Get will return the cached configuration of the given ServiceAccount.
+// It will first look at the set of ServiceAccounts configured using annotations. If none are found, it will look for any
+// ServiceAccount configured through the pod-identity-webhook ConfigMap.
 func (c *serviceAccountCache) Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64) {
 	klog.V(5).Infof("Fetching sa %s/%s from cache", namespace, name)
 	{


### PR DESCRIPTION
*Description of changes:*

This PR adds an option for the webhook to watch a configmap for additional SA to Role mappings. This is useful where there are tooling that creates IAM Roles and already know what SA should use them. In particular kOps already has this mapping. Adding the annotation to the SAs is then just additional manual work.

A few notes:
* There is a number of ways to watch a configmap. I opted for using another informer that is namespaced rather than e.g mounting it on disk and watching the file.
* Previously, all SAs were added to cache regardless of if they had the annotation. This made an empty SA override what was populated from the ConfigMap if the SA was created/changed after the CM was read. I changed this to only add to cache if the annotation is present. I believe this doesn't change much as the webhook need to handle an SA that is not in cache anyway.
* The struct used in the configmap is the same as `CacheResponse`. This takes an orignally internal struct and makes it into a public interface. Mostly something to be aware of if one wants to change this struct in the future.

/cc @nckturner 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
