### PR TITLE
Update default sts to regional

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ certificates API.
         eks.amazonaws.com/role-arn: "arn:aws:iam::111122223333:role/s3-reader"
         # optional: Defaults to "sts.amazonaws.com" if not set
         eks.amazonaws.com/audience: "sts.amazonaws.com"
-        # optional: When set to "true", adds AWS_STS_REGIONAL_ENDPOINTS env var
-        #   to containers
-        eks.amazonaws.com/sts-regional-endpoints: "true"
         # optional: Defaults to 86400 for expirationSeconds if not set
         #   Note: This value can be overwritten if specified in the pod 
         #         annotation as shown in the next step.
@@ -182,7 +179,7 @@ When the `aws-default-region` flag is set this webhook will inject `AWS_DEFAULT_
 
 ### AWS_STS_REGIONAL_ENDPOINTS Injection
 
-When the `sts-regional-endpoint` flag is set to `true`, the webhook will
+The `sts-regional-endpoint` flag is set to `true` by default. The webhook will
 inject the environment variable `AWS_STS_REGIONAL_ENDPOINTS` with the value set
 to `regional`. This environment variable will configure the AWS SDKs to perform
 the `sts:AssumeRoleWithWebIdentity` call to get credentials from the regional
@@ -190,8 +187,8 @@ endpoint, instead of the global endpoint in `us-east-1`. This is desirable in
 almost all cases, unless the STS regional endpoint is [disabled in your
 account](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html).
 
-You can also enable this per-service account with the annotation
-`eks.amazonaws.com/sts-regional-endpoints` set to `"true"`.
+You can also disable this per-service account with the annotation
+`eks.amazonaws.com/sts-regional-endpoints` set to `"false"`.
 
 ### pod-identity-webhook ConfigMap
 

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 	mountPath := flag.String("token-mount-path", "/var/run/secrets/eks.amazonaws.com/serviceaccount", "The path to mount tokens")
 	tokenExpiration := flag.Int64("token-expiration", pkg.DefaultTokenExpiration, "The token expiration")
 	region := flag.String("aws-default-region", "", "If set, AWS_DEFAULT_REGION and AWS_REGION will be set to this value in mutated containers")
-	regionalSTS := flag.Bool("sts-regional-endpoint", false, "Whether to inject the AWS_STS_REGIONAL_ENDPOINTS=regional env var in mutated pods. Defaults to `false`.")
+	regionalSTS := flag.Bool("sts-regional-endpoint", true, "Whether to inject the AWS_STS_REGIONAL_ENDPOINTS=regional env var in mutated pods. Defaults to `true`.")
 	watchConfigMap := flag.Bool("watch-config-map", false, "Enables watching serviceaccounts that are configured through the pod-identity-webhook configmap instead of using annotations")
 
 	version := flag.Bool("version", false, "Display the version and exit")


### PR DESCRIPTION
As part of https://github.com/aws/amazon-eks-pod-identity-webhook/issues/130 EKS has moved the default to regional sts. This PR makes the default flag to `true` to keep the behavior consistent across upstream and EKS.