### PR TITLE
make MinTokenExpiration configurable by cli flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func main() {
 	region := flag.String("aws-default-region", "", "If set, AWS_DEFAULT_REGION and AWS_REGION will be set to this value in mutated containers")
 	regionalSTS := flag.Bool("sts-regional-endpoint", false, "Whether to inject the AWS_STS_REGIONAL_ENDPOINTS=regional env var in mutated pods. Defaults to `false`.")
 	watchConfigMap := flag.Bool("watch-config-map", false, "Enables watching serviceaccounts that are configured through the pod-identity-webhook configmap instead of using annotations")
+	flag.Int64Var(&pkg.MinTokenExpiration, "min-token-expiration", pkg.MinTokenExpiration, "Minimum token expiration in seconds. The value is used if user configured the shorter duration than this value")
 
 	version := flag.Bool("version", false, "Display the version and exit")
 
@@ -88,6 +89,10 @@ func main() {
 	if *version {
 		fmt.Println(webhookVersion)
 		os.Exit(0)
+	}
+
+	if pkg.MinTokenExpiration < 600 {
+		klog.Fatal("min-token-expiration must be at least 600 (10 min)")
 	}
 
 	config, err := clientcmd.BuildConfigFromFlags(*apiURL, *kubeconfig)

--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -18,6 +18,12 @@ const (
 	// Default token expiration in seconds if none is defined,
 	// which is 24hrs as that is max for EKS
 	DefaultTokenExpiration = int64(86400)
-	// 1hr is min for kube-apiserver
+)
+
+var (
+	// Minimum token expiration in seconds.
+	// The value is used if user configured the shorter duration than this value
+	// This value must be at least 600(=10min) due to kubernetes spec (ref ServiceAccountTokenProjection.ExpirationSeconds).
+	// Note: this can be configured by cli flags
 	MinTokenExpiration = int64(3600)
 )


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-eks-pod-identity-webhook/issues/155

*Description of changes:*

- Changed `MinTokenExpiration` from `const` to `var`
- Introduced a cli flag `--min-token-expiration` to configure `MinTokenExpiration` with validation(it must be at least 10min).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
