### PR TITLE
add tests for grpc health probes and seccompProfile

### DIFF
--- a/pkg/handler/testdata/rawPodWithGRPC.pod.yaml
+++ b/pkg/handler/testdata/rawPodWithGRPC.pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  uid: be8695c4-4ad0-4038-8786-c508853aa255
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/handler/region: "seattle"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"seattle"},{"name":"AWS_REGION","value":"seattle"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}],"readinessProbe":{"grpc":{"port":5000,"service":null}}}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+    readinessProbe:
+      grpc:
+        port: 5000
+  serviceAccountName: default

--- a/pkg/handler/testdata/rawPodWithsecCompProfile.pod.yaml
+++ b/pkg/handler/testdata/rawPodWithsecCompProfile.pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  uid: be8695c4-4ad0-4038-8786-c508853aa255
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws:iam::111122223333:role/s3-reader"
+    testing.eks.amazonaws.com/serviceAccount/audience: "sts.amazonaws.com"
+    testing.eks.amazonaws.com/handler/region: "seattle"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_DEFAULT_REGION","value":"seattle"},{"name":"AWS_REGION","value":"seattle"},{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}],"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+  serviceAccountName: default

--- a/vendor/github.com/emicklei/go-restful/v3/log/log.go
+++ b/vendor/github.com/emicklei/go-restful/v3/log/log.go
@@ -1,0 +1,34 @@
+package log
+
+import (
+	stdlog "log"
+	"os"
+)
+
+// StdLogger corresponds to a minimal subset of the interface satisfied by stdlib log.Logger
+type StdLogger interface {
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+}
+
+var Logger StdLogger
+
+func init() {
+	// default Logger
+	SetLogger(stdlog.New(os.Stderr, "[restful] ", stdlog.LstdFlags|stdlog.Lshortfile))
+}
+
+// SetLogger sets the logger for this package
+func SetLogger(customLogger StdLogger) {
+	Logger = customLogger
+}
+
+// Print delegates to the Logger
+func Print(v ...interface{}) {
+	Logger.Print(v...)
+}
+
+// Printf delegates to the Logger
+func Printf(format string, v ...interface{}) {
+	Logger.Printf(format, v...)
+}


### PR DESCRIPTION
Signed-off-by: Davanum Srinivas <davanum@gmail.com>

*Issue #, if available:*

*Description of changes:*
Adding a test to ensure we don't break scenario in https://github.com/aws/amazon-eks-pod-identity-webhook/issues/165 and https://github.com/aws/amazon-eks-pod-identity-webhook/issues/168

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

PS: the last commit missed a file in vendor/ adding it here.