### PR TITLE
Generate an additive JSON Patch instead of overwriting containers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/prometheus/client_golang v1.12.2
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
+	gomodules.xyz/jsonpatch/v2 v2.2.0
 	gopkg.in/square/go-jose.v2 v2.5.1
 	k8s.io/api v0.25.6
 	k8s.io/apimachinery v0.25.6

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
@@ -162,6 +163,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -460,6 +462,7 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
+gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/pkg/handler/handler_pod_test.go
+++ b/pkg/handler/handler_pod_test.go
@@ -26,9 +26,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
+
+	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
 )
 
 var fixtureDir = "./testdata"

--- a/vendor/gomodules.xyz/jsonpatch/v2/LICENSE
+++ b/vendor/gomodules.xyz/jsonpatch/v2/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/gomodules.xyz/jsonpatch/v2/jsonpatch.go
+++ b/vendor/gomodules.xyz/jsonpatch/v2/jsonpatch.go
@@ -1,0 +1,334 @@
+package jsonpatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+var errBadJSONDoc = fmt.Errorf("invalid JSON Document")
+
+type JsonPatchOperation = Operation
+
+type Operation struct {
+	Operation string      `json:"op"`
+	Path      string      `json:"path"`
+	Value     interface{} `json:"value,omitempty"`
+}
+
+func (j *Operation) Json() string {
+	b, _ := json.Marshal(j)
+	return string(b)
+}
+
+func (j *Operation) MarshalJSON() ([]byte, error) {
+	var b bytes.Buffer
+	b.WriteString("{")
+	b.WriteString(fmt.Sprintf(`"op":"%s"`, j.Operation))
+	b.WriteString(fmt.Sprintf(`,"path":"%s"`, j.Path))
+	// Consider omitting Value for non-nullable operations.
+	if j.Value != nil || j.Operation == "replace" || j.Operation == "add" {
+		v, err := json.Marshal(j.Value)
+		if err != nil {
+			return nil, err
+		}
+		b.WriteString(`,"value":`)
+		b.Write(v)
+	}
+	b.WriteString("}")
+	return b.Bytes(), nil
+}
+
+type ByPath []Operation
+
+func (a ByPath) Len() int           { return len(a) }
+func (a ByPath) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByPath) Less(i, j int) bool { return a[i].Path < a[j].Path }
+
+func NewOperation(op, path string, value interface{}) Operation {
+	return Operation{Operation: op, Path: path, Value: value}
+}
+
+// CreatePatch creates a patch as specified in http://jsonpatch.com/
+//
+// 'a' is original, 'b' is the modified document. Both are to be given as json encoded content.
+// The function will return an array of JsonPatchOperations
+//
+// An error will be returned if any of the two documents are invalid.
+func CreatePatch(a, b []byte) ([]Operation, error) {
+	var aI interface{}
+	var bI interface{}
+	err := json.Unmarshal(a, &aI)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+	err = json.Unmarshal(b, &bI)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+	return handleValues(aI, bI, "", []Operation{})
+}
+
+// Returns true if the values matches (must be json types)
+// The types of the values must match, otherwise it will always return false
+// If two map[string]interface{} are given, all elements must match.
+func matchesValue(av, bv interface{}) bool {
+	if reflect.TypeOf(av) != reflect.TypeOf(bv) {
+		return false
+	}
+	switch at := av.(type) {
+	case string:
+		bt, ok := bv.(string)
+		if ok && bt == at {
+			return true
+		}
+	case float64:
+		bt, ok := bv.(float64)
+		if ok && bt == at {
+			return true
+		}
+	case bool:
+		bt, ok := bv.(bool)
+		if ok && bt == at {
+			return true
+		}
+	case map[string]interface{}:
+		bt, ok := bv.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		for key := range at {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		for key := range bt {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		return true
+	case []interface{}:
+		bt, ok := bv.([]interface{})
+		if !ok {
+			return false
+		}
+		if len(bt) != len(at) {
+			return false
+		}
+		for key := range at {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		for key := range bt {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// From http://tools.ietf.org/html/rfc6901#section-4 :
+//
+// Evaluation of each reference token begins by decoding any escaped
+// character sequence.  This is performed by first transforming any
+// occurrence of the sequence '~1' to '/', and then transforming any
+// occurrence of the sequence '~0' to '~'.
+//   TODO decode support:
+//   var rfc6901Decoder = strings.NewReplacer("~1", "/", "~0", "~")
+
+var rfc6901Encoder = strings.NewReplacer("~", "~0", "/", "~1")
+
+func makePath(path string, newPart interface{}) string {
+	key := rfc6901Encoder.Replace(fmt.Sprintf("%v", newPart))
+	if path == "" {
+		return "/" + key
+	}
+	if strings.HasSuffix(path, "/") {
+		return path + key
+	}
+	return path + "/" + key
+}
+
+// diff returns the (recursive) difference between a and b as an array of JsonPatchOperations.
+func diff(a, b map[string]interface{}, path string, patch []Operation) ([]Operation, error) {
+	for key, bv := range b {
+		p := makePath(path, key)
+		av, ok := a[key]
+		// value was added
+		if !ok {
+			patch = append(patch, NewOperation("add", p, bv))
+			continue
+		}
+		// Types are the same, compare values
+		var err error
+		patch, err = handleValues(av, bv, p, patch)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Now add all deleted values as nil
+	for key := range a {
+		_, found := b[key]
+		if !found {
+			p := makePath(path, key)
+
+			patch = append(patch, NewOperation("remove", p, nil))
+		}
+	}
+	return patch, nil
+}
+
+func handleValues(av, bv interface{}, p string, patch []Operation) ([]Operation, error) {
+	{
+		at := reflect.TypeOf(av)
+		bt := reflect.TypeOf(bv)
+		if at == nil && bt == nil {
+			// do nothing
+			return patch, nil
+		} else if at != bt {
+			// If types have changed, replace completely (preserves null in destination)
+			return append(patch, NewOperation("replace", p, bv)), nil
+		}
+	}
+
+	var err error
+	switch at := av.(type) {
+	case map[string]interface{}:
+		bt := bv.(map[string]interface{})
+		patch, err = diff(at, bt, p, patch)
+		if err != nil {
+			return nil, err
+		}
+	case string, float64, bool:
+		if !matchesValue(av, bv) {
+			patch = append(patch, NewOperation("replace", p, bv))
+		}
+	case []interface{}:
+		bt := bv.([]interface{})
+		if isSimpleArray(at) && isSimpleArray(bt) {
+			patch = append(patch, compareEditDistance(at, bt, p)...)
+		} else {
+			n := min(len(at), len(bt))
+			for i := len(at) - 1; i >= n; i-- {
+				patch = append(patch, NewOperation("remove", makePath(p, i), nil))
+			}
+			for i := n; i < len(bt); i++ {
+				patch = append(patch, NewOperation("add", makePath(p, i), bt[i]))
+			}
+			for i := 0; i < n; i++ {
+				var err error
+				patch, err = handleValues(at[i], bt[i], makePath(p, i), patch)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	default:
+		panic(fmt.Sprintf("Unknown type:%T ", av))
+	}
+	return patch, nil
+}
+
+func isBasicType(a interface{}) bool {
+	switch a.(type) {
+	case string, float64, bool:
+	default:
+		return false
+	}
+	return true
+}
+
+func isSimpleArray(a []interface{}) bool {
+	for i := range a {
+		switch a[i].(type) {
+		case string, float64, bool:
+		default:
+			val := reflect.ValueOf(a[i])
+			if val.Kind() == reflect.Map {
+				for _, k := range val.MapKeys() {
+					av := val.MapIndex(k)
+					if av.Kind() == reflect.Ptr || av.Kind() == reflect.Interface {
+						if av.IsNil() {
+							continue
+						}
+						av = av.Elem()
+					}
+					if av.Kind() != reflect.String && av.Kind() != reflect.Float64 && av.Kind() != reflect.Bool {
+						return false
+					}
+				}
+				return true
+			}
+			return false
+		}
+	}
+	return true
+}
+
+// https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm
+// Adapted from https://github.com/texttheater/golang-levenshtein
+func compareEditDistance(s, t []interface{}, p string) []Operation {
+	m := len(s)
+	n := len(t)
+
+	d := make([][]int, m+1)
+	for i := 0; i <= m; i++ {
+		d[i] = make([]int, n+1)
+		d[i][0] = i
+	}
+	for j := 0; j <= n; j++ {
+		d[0][j] = j
+	}
+
+	for j := 1; j <= n; j++ {
+		for i := 1; i <= m; i++ {
+			if reflect.DeepEqual(s[i-1], t[j-1]) {
+				d[i][j] = d[i-1][j-1] // no op required
+			} else {
+				del := d[i-1][j] + 1
+				add := d[i][j-1] + 1
+				rep := d[i-1][j-1] + 1
+				d[i][j] = min(rep, min(add, del))
+			}
+		}
+	}
+
+	return backtrace(s, t, p, m, n, d)
+}
+
+func min(x int, y int) int {
+	if y < x {
+		return y
+	}
+	return x
+}
+
+func backtrace(s, t []interface{}, p string, i int, j int, matrix [][]int) []Operation {
+	if i > 0 && matrix[i-1][j]+1 == matrix[i][j] {
+		op := NewOperation("remove", makePath(p, i-1), nil)
+		return append([]Operation{op}, backtrace(s, t, p, i-1, j, matrix)...)
+	}
+	if j > 0 && matrix[i][j-1]+1 == matrix[i][j] {
+		op := NewOperation("add", makePath(p, i), t[j-1])
+		return append([]Operation{op}, backtrace(s, t, p, i, j-1, matrix)...)
+	}
+	if i > 0 && j > 0 && matrix[i-1][j-1]+1 == matrix[i][j] {
+		if isBasicType(s[0]) {
+			op := NewOperation("replace", makePath(p, i-1), t[j-1])
+			return append([]Operation{op}, backtrace(s, t, p, i-1, j-1, matrix)...)
+		}
+
+		p2, _ := handleValues(s[i-1], t[j-1], makePath(p, i-1), []Operation{})
+		return append(p2, backtrace(s, t, p, i-1, j-1, matrix)...)
+	}
+	if i > 0 && j > 0 && matrix[i-1][j-1] == matrix[i][j] {
+		return backtrace(s, t, p, i-1, j-1, matrix)
+	}
+	return []Operation{}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -154,6 +154,9 @@ golang.org/x/text/width
 # golang.org/x/time v0.0.0-20220609170525-579cf78fd858
 ## explicit
 golang.org/x/time/rate
+# gomodules.xyz/jsonpatch/v2 v2.2.0
+## explicit; go 1.12
+gomodules.xyz/jsonpatch/v2
 # google.golang.org/appengine v1.6.7
 ## explicit; go 1.11
 google.golang.org/appengine/internal


### PR DESCRIPTION
*Issue #, if available:* 165

*Description of changes:* 

The problem in #165 is that the code is serializing the k8s.io structs as is, with an 'add' operation that effectively replaces the Container in the PodSpec. This works until fields are added, like grpc, at which point this webhook has to be updated, or it will drop the new fields.

Instead of serializing the entire container struct, this uses jsonpatch to create a diff from the modifications, and generated a targeted patch that only adds and modifies the things it needs to. Unknown fields will not be dropped.

I've not updated the test cases as they are hardcoded to expect a specific patch (that will drop unknown fields.) TBH, that approach needs to be rethought.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
