### PR TITLE
fix: Reintroduce mutatingwebhook.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,12 +78,14 @@ deploy-config: prep-config
 	kubectl apply -f deploy/auth.yaml
 	kubectl apply -f deploy/deployment.yaml
 	kubectl apply -f deploy/service.yaml
+	kubectl apply -f deploy/mutatingwebhook.yaml
 
 delete-config:
 	@echo 'Tearing down mutating controller and associated resources...'
 	kubectl delete -f deploy/service.yaml
 	kubectl delete -f deploy/deployment.yaml
 	kubectl delete -f deploy/auth.yaml
+	kubectl delete -f deploy/mutatingwebhook.yaml
 	kubectl delete secret pod-identity-webhook-cert
 
 clean::


### PR DESCRIPTION
It looks like when the webhook ca stuff was removed the mutatingwebhook.yaml was removed as well.

This commit simply adds the corresponding aply and delete for that manifest.

*Issue #, if available:*
closes #176 

*Description of changes:*
This commit simply adds the corresponding aply and delete for that manifest.

I have tested this by running cluster-up and cluster-down on my own clusters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
