### PR TITLE
cache: Use regexp to match wildcards stored in configmap

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -18,6 +18,7 @@ package cache
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -107,11 +108,14 @@ func (c *serviceAccountCache) getSA(name, namespace string) *CacheResponse {
 func (c *serviceAccountCache) getCM(name, namespace string) *CacheResponse {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	resp, ok := c.cmCache[namespace+"/"+name]
-	if !ok {
-		return nil
+	for key, resp := range c.cmCache {
+		pattern := strings.Replace(key, "*", ".*", -1) // replace * with .*
+		regex := regexp.MustCompile(pattern)
+		if regex.MatchString(namespace + "/" + name) {
+			return resp
+		}
 	}
-	return resp
+	return nil
 }
 
 func (c *serviceAccountCache) popSA(name, namespace string) {


### PR DESCRIPTION
*Description of changes:*

When enabling the configmap watcher, [the README provides an example configmap which uses a wildcard character for matching service accounts across multiple namespaces](https://github.com/aws/amazon-eks-pod-identity-webhook/blob/master/README.md#pod-identity-webhook-configmap). However, during testing I found that this did not work due to the way that the webhook does a direct match from the corresponding service account and the cache entries. 

We desire this functionality as we have the same service account name across multiple namespaces which needs the same role ARN assigned. Since we run the same across multiple environments as well, the role ARN is different due to account IDs etc.

This PR adds functionality to support the documented feature by iterating through cache entries and performing a regex match for any wildcard characters that are defined in the configmap with the requesting namespace/service-account-name.

We have done limited testing on this and confirm that it is working as desired as well as configmap entries that do not contain wildcards.

I would welcome any suggestions or changes as I am not too familiar with the codebase (or the performance impacts of using regexp), but would love to get this merged if possible to solve our use case.

Thanks!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
