### PR TITLE
add ecr publish configuration

### DIFF
--- a/.github/workflows/publish_ecr.yaml
+++ b/.github/workflows/publish_ecr.yaml
@@ -1,0 +1,77 @@
+name: Publish to ECR
+on:
+  push:
+    tags: ['*']
+jobs:
+  ecr-private:
+    name: Push to ECR Private
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        role-session-name: GitHubCI
+        aws-region: us-east-1
+        role-duration-seconds: 1800
+        role-skip-session-tagging: true
+
+    - name: Login to Amazon ECR
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Set environment variables
+      env:
+        REGISTRY: ${{ secrets.ECR_PRIVATE_REPOSITORY }}
+      run: |
+          echo "REGISTRY=${REGISTRY}" >> $GITHUB_ENV
+          echo "TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+
+    - name: Build, tag, and push manifest to Amazon ECR
+      run: make -j `nproc` all-push
+
+  ecr-public:
+    name: Push to ECR Public
+    runs-on: ubuntu-latest
+    environment: ecr-public
+    needs: ecr-private
+
+    steps:
+    - name: Set up crane
+      uses: imjasonh/setup-crane@v0.1
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        role-session-name: GitHubCI
+        aws-region: us-east-1
+        role-duration-seconds: 1800
+        role-skip-session-tagging: true
+
+    - name: Login to Amazon ECR
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Login to Amazon ECR Public
+      uses: aws-actions/amazon-ecr-login@v1
+      with:
+        registry-type: public
+
+    - name: Copy manifest to ECR Public
+      env:
+        ECR_PRIVATE_REPOSITORY: ${{ secrets.ECR_PRIVATE_REPOSITORY }}
+        ECR_PUBLIC_REPOSITORY: ${{ secrets.ECR_PUBLIC_REPOSITORY }}
+      run: crane copy ${ECR_PRIVATE_REPOSITORY}/amazon-eks-pod-identity-webhook:${GITHUB_REF_NAME} ${ECR_PUBLIC_REPOSITORY}/amazon-eks-pod-identity-webhook:${GITHUB_REF_NAME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,37 @@
-FROM golang:1.19 AS builder
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-WORKDIR $GOPATH/src/github.com/aws/amazon-eks-pod-identity-webhook
-COPY . ./
-RUN GOPROXY=direct CGO_ENABLED=0 GOOS=linux go build -o /webhook -v -a -installsuffix nocgo -ldflags="-buildid='' -w -s" .
+# See
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+# for info on BUILDPLATFORM, TARGETOS, TARGETARCH, etc.
+FROM --platform=$BUILDPLATFORM golang:1.19 AS builder
+WORKDIR /go/src/github.com/aws/amazon-eks-pod-identity-webhook
+COPY go.* .
+ARG GOPROXY
+RUN go mod download
+COPY . .
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION
+RUN OS=$TARGETOS ARCH=$TARGETARCH make bin/github.com/aws/amazon-eks-pod-identity-webhook/webhook
 
-FROM scratch
+# TODO: Is this the best base?
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:latest.2 AS linux-amazon
 COPY ATTRIBUTIONS.txt /ATTRIBUTIONS.txt
-COPY --from=builder /webhook /webhook
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /go/src/github.com/aws/amazon-eks-pod-identity-webhook/bin/github.com/aws/amazon-eks-pod-identity-webhook/webhook /bin/webhook
 EXPOSE 443
 VOLUME /etc/webhook
-ENTRYPOINT ["/webhook"]
+ENTRYPOINT ["/bin/webhook"]
 CMD ["--logtostderr"]

--- a/Makefile
+++ b/Makefile
@@ -2,39 +2,96 @@
 -include build/private/bgo_exports.makefile
 include ${BGO_MAKEFILE}
 
-export CGO_ENABLED=0
-export T=github.com/aws/amazon-eks-pod-identity-webhook
-UNAME_S = $(shell uname -s)
-GO_LDFLAGS = -ldflags='-s -w -buildid=""'
-
-install:: build
-ifeq ($(UNAME_S), Darwin)
-	GOOS=darwin GOARCH=amd64 go build -o build/gopath/bin/darwin_amd64/amazon-eks-pod-identity-webhook $(GO_LDFLAGS) $V $T
-endif
-	GOOS=linux GOARCH=amd64 go build -o build/gopath/bin/linux_amd64/amazon-eks-pod-identity-webhook $(GO_LDFLAGS) $V $T
-
-# Generic make
-REGISTRY_ID?=602401143452
-IMAGE_NAME?=eks/pod-identity-webhook
-REGION?=us-west-2
-IMAGE?=$(REGISTRY_ID).dkr.ecr.$(REGION).amazonaws.com/$(IMAGE_NAME)
-
 test:
 	go test -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out
 
-docker:
-	@echo 'Building image $(IMAGE)...'
-	docker build --no-cache -t $(IMAGE) .
+VERSION?=v0.4.0
 
-push: docker
-	if ! aws ecr get-login-password --region $(REGION) | docker login --username AWS --password-stdin $(REGISTRY_ID).dkr.ecr.$(REGION).amazonaws.com; then \
-	  eval $$(aws ecr get-login --registry-ids $(REGISTRY_ID) --no-include-email); \
-	fi
-	docker push $(IMAGE)
+PKG=github.com/aws/amazon-eks-pod-identity-webhook
+GIT_COMMIT?=$(shell git rev-parse HEAD)
+BUILD_DATE?=$(shell date -u -Iseconds)
+LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/cloud.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"
 
-amazon-eks-pod-identity-webhook:
-	go build
+
+GO111MODULE=on
+GOPATH=$(shell go env GOPATH)
+GOOS=$(shell go env GOOS)
+GOBIN=$(shell pwd)/bin
+
+# TODO: Is this still an appropriate default?
+REGISTRY?=gcr.io/k8s-staging-provider-aws
+IMAGE?=$(REGISTRY)/amazon-eks-pod-identity-webhook
+TAG?=$(GIT_COMMIT)
+
+OUTPUT_TYPE?=docker
+
+OS?=linux
+ARCH?=amd64
+OSVERSION?=amazon
+
+ALL_OS?=linux
+ALL_ARCH_linux?=amd64 arm64
+ALL_OSVERSION_linux?=amazon
+ALL_OS_ARCH_OSVERSION_linux=$(foreach arch, $(ALL_ARCH_linux), $(foreach osversion, ${ALL_OSVERSION_linux}, linux-$(arch)-${osversion}))
+
+ALL_OS_ARCH_OSVERSION=$(foreach os, $(ALL_OS), ${ALL_OS_ARCH_OSVERSION_${os}})
+
+# split words on hyphen, access by 1-index
+word-hyphen = $(word $2,$(subst -, ,$1))
+
+.EXPORT_ALL_VARIABLES:
+
+.PHONY: linux/$(ARCH) bin/${PKG}/amazon-eks-pod-identity-webhook
+linux/$(ARCH): bin/${PKG}/amazon-eks-pod-identity-webhook
+bin/${PKG}/amazon-eks-pod-identity-webhook: | bin
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -mod=mod -ldflags ${LDFLAGS} -o bin/${PKG}/webhook
+
+# Builds all linux and windows images and pushes them
+.PHONY: all-push
+all-push: all-image-registry push-manifest
+
+.PHONY: push-manifest
+push-manifest: create-manifest
+	docker manifest push --purge $(IMAGE):$(TAG)
+
+.PHONY: create-manifest
+create-manifest: all-image-registry
+# sed expression:
+# LHS: match 0 or more not space characters
+# RHS: replace with $(IMAGE):$(TAG)-& where & is what was matched on LHS
+	docker manifest create --amend $(IMAGE):$(TAG) $(shell echo $(ALL_OS_ARCH_OSVERSION) | sed -e "s~[^ ]*~$(IMAGE):$(TAG)\-&~g")
+
+# Only linux for OUTPUT_TYPE=docker because windows image cannot be exported
+# "Currently, multi-platform images cannot be exported with the docker export type. The most common usecase for multi-platform images is to directly push to a registry (see registry)."
+# https://docs.docker.com/engine/reference/commandline/buildx_build/#output
+.PHONY: all-image-docker
+all-image-docker: $(addprefix sub-image-docker-,$(ALL_OS_ARCH_OSVERSION_linux))
+.PHONY: all-image-registry
+all-image-registry: $(addprefix sub-image-registry-,$(ALL_OS_ARCH_OSVERSION))
+
+sub-image-%:
+	$(MAKE) OUTPUT_TYPE=$(call word-hyphen,$*,1) OS=$(call word-hyphen,$*,2) ARCH=$(call word-hyphen,$*,3) OSVERSION=$(call word-hyphen,$*,4) image
+
+.PHONY: image
+image: .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
+.image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION):
+	docker buildx build \
+		--platform=$(OS)/$(ARCH) \
+		--progress=plain \
+		--target=$(OS)-$(OSVERSION) \
+		--output=type=$(OUTPUT_TYPE) \
+		-t=$(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) \
+		--build-arg=GOPROXY=$(GOPROXY) \
+		--build-arg=VERSION=$(VERSION) \
+		`./hack/provenance` \
+		.
+	touch $@
+
+amazon-eks-pod-identity-webhook: bin/${PKG}/amazon-eks-pod-identity-webhook
+
+build: amazon-eks-pod-identity-webhook
+	cp bin/${PKG}/webhook ./amazon-eks-pod-identity-webhook
 
 certs/tls.key:
 	mkdir -p certs
@@ -89,8 +146,13 @@ delete-config:
 	kubectl delete secret pod-identity-webhook-cert
 
 clean::
+	rm -rf .*image-*
+	rm -rf ./bin/
 	rm -rf ./amazon-eks-pod-identity-webhook
 	rm -rf ./certs/ coverage.out
+
+bin:
+	@mkdir -p $@
 
 .PHONY: docker push build local-serve local-request cluster-up cluster-down prep-config deploy-config delete-config clean
 

--- a/hack/provenance
+++ b/hack/provenance
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# There is no reliable way to check if a buildx installation supports
+# --provenance other than trying to execute it. You cannot even rely
+# on the version, because buildx's own installation docs will result
+# in installations of buildx that do not correctly report their version
+# via `docker buildx version`.
+#
+# Additionally, if the local buildkit worker is the Docker daemon,
+# attestation should not be supported and must be disabled.
+#
+# Thus, this script echos back the flag `--provenance=false` if and only
+# if the local buildx installation supports it. If not, it exits silently.
+
+BUILDX_TEST=`docker buildx build --provenance=false 2>&1`
+if [[ "${BUILDX_TEST}" == *"See 'docker buildx build --help'."* ]]; then
+  if [[ "${BUILDX_TEST}" == *"requires exactly 1 argument"* ]] && ! docker buildx inspect | grep -qE "^Driver:\s*docker$"; then
+    echo "--provenance=false"
+  fi
+else
+  echo "Local buildx installation broken?" >&2
+  exit 1
+fi


### PR DESCRIPTION
*Issue #, if available:*
#141 
*Description of changes:*
This makes modifications to support a publish workflow for this repo's docker image to public ECR and follows https://github.com/kubernetes-sigs/aws-ebs-csi-driver. This required modifying the Makefile to support multiarch building, the Dockerfile to support multiarch builds as well, and a provenance test script during the build process. These changes are then used in the new publish-ecr workflow copied from the aws-ebs-csi repo. The architectures supported are linux/arm64 and linux/amd64

`make all-images` creates the necessary images for local development, and make build was refactored to use the local systems ARCH be used in the build process. This will keep compatibility with the existing make steps

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
