### PR TITLE
Enable cross-compilation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM golang:1.19 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.19 AS builder
 
 WORKDIR $GOPATH/src/github.com/aws/amazon-eks-pod-identity-webhook
 COPY . ./
-RUN GOPROXY=direct CGO_ENABLED=0 GOOS=linux go build -o /webhook -v -a -installsuffix nocgo -ldflags="-buildid='' -w -s" .
+ARG TARGETOS TARGETARCH
+RUN GOPROXY=direct CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /webhook -v -a -installsuffix nocgo -ldflags="-buildid='' -w -s" .
 
 FROM scratch
 COPY ATTRIBUTIONS.txt /ATTRIBUTIONS.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM golang:1.19 AS builder
 WORKDIR $GOPATH/src/github.com/aws/amazon-eks-pod-identity-webhook
 COPY . ./
 ARG TARGETOS TARGETARCH
-RUN GOPROXY=direct CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /webhook -v -a -installsuffix nocgo -ldflags="-buildid='' -w -s" .
+RUN GOPROXY=direct CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /webhook -v -a -ldflags="-buildid='' -w -s" .
 
 FROM scratch
 COPY ATTRIBUTIONS.txt /ATTRIBUTIONS.txt

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test:
 
 docker:
 	@echo 'Building image $(IMAGE)...'
-	docker build --no-cache -t $(IMAGE) .
+	docker buildx build --output=type=docker --platform linux/amd64 --no-cache -t $(IMAGE) .
 
 push: docker
 	if ! aws ecr get-login-password --region $(REGION) | docker login --username AWS --password-stdin $(REGISTRY_ID).dkr.ecr.$(REGION).amazonaws.com; then \


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Enable cross-compilation in Dockerfile. We need to add ARG TARGETOS TARGETARCH for them to be populated by buildx.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
