### PR TITLE
Use eks-distro go-runner as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,7 @@ COPY . ./
 ARG TARGETOS TARGETARCH
 RUN GOPROXY=direct CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /webhook -v -a -ldflags="-buildid='' -w -s" .
 
-FROM scratch
-COPY ATTRIBUTIONS.txt /ATTRIBUTIONS.txt
+FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro/kubernetes/go-runner:v0.13.0-eks-1-23-latest
 COPY --from=builder /webhook /webhook
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-EXPOSE 443
-VOLUME /etc/webhook
-ENTRYPOINT ["/webhook"]
-CMD ["--logtostderr"]
+ENTRYPOINT ["/go-runner"]
+CMD ["/webhook"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Use eks-distro go-runner as the base image instead of `scratch` so we can utilize go-runner to output stderr and stdout of the container to a file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
