### PR TITLE
Upgrade Go compiler to version 1.21 and update base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM --platform=$BUILDPLATFORM golang:1.19 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.21 AS builder
 
 WORKDIR $GOPATH/src/github.com/aws/amazon-eks-pod-identity-webhook
 COPY . ./
 ARG TARGETOS TARGETARCH
 RUN GOPROXY=direct CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /webhook -v -a -ldflags="-buildid='' -w -s" .
 
-FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro/kubernetes/go-runner:v0.13.0-eks-1-23-latest
+FROM --platform=$TARGETPLATFORM public.ecr.aws/eks-distro/kubernetes/go-runner:v0.15.1-eks-1-28-latest
 COPY --from=builder /webhook /webhook
 ENTRYPOINT ["/go-runner"]
 CMD ["/webhook"]


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes:*

Upgrade Go compiler to version `1.21` and update base image (`eks/go-runner`) version


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
