### PR TITLE
Update container credentials method to use a different mount path

### DIFF
--- a/pkg/containercredentials/config.go
+++ b/pkg/containercredentials/config.go
@@ -29,8 +29,11 @@ type Config interface {
 }
 
 type FileConfig struct {
-	audience string
-	fullUri  string
+	audience   string
+	mountPath  string
+	volumeName string
+	tokenPath  string
+	fullUri    string
 
 	watcher              *filesystem.FileWatcher
 	identityConfigObject *IdentityConfigObject
@@ -39,13 +42,19 @@ type FileConfig struct {
 }
 
 type PatchConfig struct {
-	Audience string
-	FullUri  string
+	Audience   string
+	MountPath  string
+	VolumeName string
+	TokenPath  string
+	FullUri    string
 }
 
-func NewFileConfig(audience, fullUri string) *FileConfig {
+func NewFileConfig(audience, mountPath, volumeName, tokenPath, fullUri string) *FileConfig {
 	return &FileConfig{
 		audience:             audience,
+		mountPath:            mountPath,
+		volumeName:           volumeName,
+		tokenPath:            tokenPath,
 		fullUri:              fullUri,
 		identityConfigObject: nil,
 		cache:                make(map[Identity]bool),
@@ -95,8 +104,11 @@ func (f *FileConfig) Get(namespace string, serviceAccount string) *PatchConfig {
 	}
 	if f.getCacheItem(key) {
 		return &PatchConfig{
-			Audience: f.audience,
-			FullUri:  f.fullUri,
+			Audience:   f.audience,
+			MountPath:  f.mountPath,
+			VolumeName: f.volumeName,
+			TokenPath:  f.tokenPath,
+			FullUri:    f.fullUri,
 		}
 	}
 

--- a/pkg/containercredentials/config_test.go
+++ b/pkg/containercredentials/config_test.go
@@ -32,8 +32,11 @@ const (
 	namespaceBar               = "bar"
 	namespaceBarServiceAccount = "ns-bar-sa"
 
-	audience = "audience"
-	fullUri  = "fullUri"
+	audience   = "audience"
+	mountPath  = "mountPath"
+	volumeName = "volumeName"
+	tokenName  = "tokenName"
+	fullUri    = "fullUri"
 
 	defaultTimeout      = 10 * time.Second
 	defaultPollInterval = 1 * time.Second
@@ -50,7 +53,7 @@ func TestFileConfig_Watcher(t *testing.T) {
 	filePath := filepath.Join(dirPath, "file")
 	assert.NoError(t, os.WriteFile(filePath, defaultConfigObjectBytes(), 0666))
 
-	fileConfig := NewFileConfig(audience, fullUri)
+	fileConfig := NewFileConfig(audience, mountPath, volumeName, tokenName, fullUri)
 	assert.NoError(t, fileConfig.StartWatcher(ctx, filePath))
 	verifyConfigObject(t, fileConfig, defaultConfigObject())
 
@@ -66,7 +69,7 @@ func TestFileConfig_Watcher(t *testing.T) {
 }
 
 func TestFileConfig_WatcherNotStarted(t *testing.T) {
-	fileConfig := NewFileConfig(audience, fullUri)
+	fileConfig := NewFileConfig(audience, mountPath, volumeName, tokenName, fullUri)
 	patchConfig := fileConfig.Get("non-existent", "non-existent")
 	assert.Nil(t, patchConfig)
 }
@@ -102,7 +105,7 @@ func TestFileConfig_Load(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			fileConfig := NewFileConfig(audience, fullUri)
+			fileConfig := NewFileConfig(audience, mountPath, volumeName, tokenName, fullUri)
 			err := fileConfig.Load(tc.input)
 
 			if tc.expectError {
@@ -117,7 +120,7 @@ func TestFileConfig_Load(t *testing.T) {
 }
 
 func TestFileConfig_Get(t *testing.T) {
-	fileConfig := NewFileConfig(audience, fullUri)
+	fileConfig := NewFileConfig(audience, mountPath, volumeName, tokenName, fullUri)
 	err := fileConfig.Load(defaultConfigObjectBytes())
 	assert.NoError(t, err)
 

--- a/pkg/containercredentials/fake.go
+++ b/pkg/containercredentials/fake.go
@@ -16,28 +16,30 @@
 package containercredentials
 
 type FakeConfig struct {
-	ContainerCredentialsAudience string
-	ContainerCredentialsFullUri  string
-	Identities                   map[Identity]bool
-}
-
-func NewFakeConfig(containerCredentialsAudience, containerCredentialsFullUri string, identities map[Identity]bool) *FakeConfig {
-	return &FakeConfig{
-		ContainerCredentialsAudience: containerCredentialsAudience,
-		ContainerCredentialsFullUri:  containerCredentialsFullUri,
-		Identities:                   identities,
-	}
+	Audience   string
+	MountPath  string
+	VolumeName string
+	TokenPath  string
+	FullUri    string
+	Identities map[Identity]bool
 }
 
 func (f *FakeConfig) Get(namespace string, serviceAccount string) *PatchConfig {
+	if f.Identities == nil {
+		return nil
+	}
+
 	key := Identity{
 		Namespace:      namespace,
 		ServiceAccount: serviceAccount,
 	}
 	if _, ok := f.Identities[key]; ok {
 		return &PatchConfig{
-			Audience: f.ContainerCredentialsAudience,
-			FullUri:  f.ContainerCredentialsFullUri,
+			Audience:   f.Audience,
+			MountPath:  f.MountPath,
+			VolumeName: f.VolumeName,
+			TokenPath:  f.TokenPath,
+			FullUri:    f.FullUri,
 		}
 	}
 

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -46,7 +46,7 @@ func TestMutatePod(t *testing.T) {
 
 	modifier := NewModifier(
 		WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount)),
-		WithContainerCredentialsConfig(containercredentials.NewFakeConfig("", "", nil)),
+		WithContainerCredentialsConfig(&containercredentials.FakeConfig{}),
 	)
 	cases := []struct {
 		caseName string
@@ -81,7 +81,7 @@ func TestMutatePod(t *testing.T) {
 func TestMutatePod_MutationNotNeeded(t *testing.T) {
 	modifier := NewModifier(
 		WithServiceAccountCache(cache.NewFakeServiceAccountCache()),
-		WithContainerCredentialsConfig(containercredentials.NewFakeConfig("", "", nil)),
+		WithContainerCredentialsConfig(&containercredentials.FakeConfig{}),
 	)
 	response := modifier.MutatePod(getValidReview(rawPodWithoutVolume))
 	assert.NotNil(t, response)
@@ -164,7 +164,7 @@ func TestModifierHandler(t *testing.T) {
 
 	modifier := NewModifier(
 		WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount)),
-		WithContainerCredentialsConfig(containercredentials.NewFakeConfig("", "", nil)),
+		WithContainerCredentialsConfig(&containercredentials.FakeConfig{}),
 	)
 
 	ts := httptest.NewServer(

--- a/pkg/handler/testdata/containercredentials/rawPodNeedsAll.pod.yaml
+++ b/pkg/handler/testdata/containercredentials/rawPodNeedsAll.pod.yaml
@@ -8,9 +8,12 @@ metadata:
     testing.eks.amazonaws.com/serviceAccount/token-expiration: "10000"
     testing.eks.amazonaws.com/containercredentials/uri: "con-creds-uri"
     testing.eks.amazonaws.com/containercredentials/audience: "con-creds-aud"
+    testing.eks.amazonaws.com/containercredentials/mountPath: "/con-creds-mount-path"
+    testing.eks.amazonaws.com/containercredentials/volumeName: "con-creds-volume-name"
+    testing.eks.amazonaws.com/containercredentials/tokenPath: "con-creds-token-path"
     testing.eks.amazonaws.com/handler/injectSTS: "true"
     testing.eks.amazonaws.com/handler/region: "cn-north-1"
-    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"con-creds-aud","expirationSeconds":10000,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_STS_REGIONAL_ENDPOINTS","value":"regional"},{"name":"AWS_DEFAULT_REGION","value":"cn-north-1"},{"name":"AWS_REGION","value":"cn-north-1"},{"name":"AWS_CONTAINER_CREDENTIALS_FULL_URI","value":"con-creds-uri"},{"name":"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"con-creds-volume-name","projected":{"sources":[{"serviceAccountToken":{"audience":"con-creds-aud","expirationSeconds":10000,"path":"con-creds-token-path"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_STS_REGIONAL_ENDPOINTS","value":"regional"},{"name":"AWS_DEFAULT_REGION","value":"cn-north-1"},{"name":"AWS_REGION","value":"cn-north-1"},{"name":"AWS_CONTAINER_CREDENTIALS_FULL_URI","value":"con-creds-uri"},{"name":"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE","value":"/con-creds-mount-path/con-creds-token-path"}],"resources":{},"volumeMounts":[{"name":"con-creds-volume-name","readOnly":true,"mountPath":"/con-creds-mount-path"}]}]}]'
 spec:
   containers:
   - image: amazonlinux

--- a/pkg/handler/testdata/containercredentials/rawPodSkip.pod.yaml
+++ b/pkg/handler/testdata/containercredentials/rawPodSkip.pod.yaml
@@ -6,7 +6,10 @@ metadata:
     testing.eks.amazonaws.com/skip: "false"
     testing.eks.amazonaws.com/containercredentials/uri: "con-creds-uri"
     testing.eks.amazonaws.com/containercredentials/audience: "con-creds-aud"
-    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"con-creds-aud","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"sidecar","image":"amazonlinux","resources":{}},{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_CONTAINER_CREDENTIALS_FULL_URI","value":"con-creds-uri"},{"name":"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+    testing.eks.amazonaws.com/containercredentials/mountPath: "/con-creds-mount-path"
+    testing.eks.amazonaws.com/containercredentials/volumeName: "con-creds-volume-name"
+    testing.eks.amazonaws.com/containercredentials/tokenPath: "con-creds-token-path"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"con-creds-volume-name","projected":{"sources":[{"serviceAccountToken":{"audience":"con-creds-aud","expirationSeconds":86400,"path":"con-creds-token-path"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"sidecar","image":"amazonlinux","resources":{}},{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_CONTAINER_CREDENTIALS_FULL_URI","value":"con-creds-uri"},{"name":"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE","value":"/con-creds-mount-path/con-creds-token-path"}],"resources":{},"volumeMounts":[{"name":"con-creds-volume-name","readOnly":true,"mountPath":"/con-creds-mount-path"}]}]}]'
     # Pod Annotation
     eks.amazonaws.com/skip-containers: "sidecar"
 spec:

--- a/pkg/handler/testdata/containercredentials/rawPodWithConflictingVolumeMount.pod.yaml
+++ b/pkg/handler/testdata/containercredentials/rawPodWithConflictingVolumeMount.pod.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  uid: be8695c4-4ad0-4038-8786-c508853aa255
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/containercredentials/uri: "con-creds-uri"
+    testing.eks.amazonaws.com/containercredentials/audience: "con-creds-aud"
+    testing.eks.amazonaws.com/containercredentials/mountPath: "/con-creds-mount-path"
+    testing.eks.amazonaws.com/containercredentials/volumeName: "con-creds-volume-name"
+    testing.eks.amazonaws.com/containercredentials/tokenPath: "con-creds-token-path"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_CONTAINER_CREDENTIALS_FULL_URI","value":"con-creds-uri"},{"name":"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE","value":"/con-creds-mount-path/con-creds-token-path"}],"resources":{},"volumeMounts":[{"name":"con-creds-volume-name","readOnly":true,"mountPath":"/some/other/path"}]}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+    volumeMounts:
+      - mountPath: /some/other/path
+        name: con-creds-volume-name
+        readOnly: true
+  serviceAccountName: default
+  volumes:
+  - name: con-creds-volume-name
+    hostPath:
+      path: token

--- a/pkg/handler/testdata/containercredentials/rawPodWithRoleArn.pod.yaml
+++ b/pkg/handler/testdata/containercredentials/rawPodWithRoleArn.pod.yaml
@@ -10,7 +10,10 @@ metadata:
     testing.eks.amazonaws.com/serviceAccount/roleArn: "arn:aws-cn:iam::111122223333:role/s3-reader"
     testing.eks.amazonaws.com/containercredentials/uri: "con-creds-uri"
     "testing.eks.amazonaws.com/containercredentials/audience": "con-creds-aud"
-    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"con-creds-aud","expirationSeconds":10000,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_STS_REGIONAL_ENDPOINTS","value":"regional"},{"name":"AWS_CONTAINER_CREDENTIALS_FULL_URI","value":"con-creds-uri"},{"name":"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+    testing.eks.amazonaws.com/containercredentials/mountPath: "/con-creds-mount-path"
+    testing.eks.amazonaws.com/containercredentials/volumeName: "con-creds-volume-name"
+    testing.eks.amazonaws.com/containercredentials/tokenPath: "con-creds-token-path"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"con-creds-volume-name","projected":{"sources":[{"serviceAccountToken":{"audience":"con-creds-aud","expirationSeconds":10000,"path":"con-creds-token-path"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_STS_REGIONAL_ENDPOINTS","value":"regional"},{"name":"AWS_CONTAINER_CREDENTIALS_FULL_URI","value":"con-creds-uri"},{"name":"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE","value":"/con-creds-mount-path/con-creds-token-path"}],"resources":{},"volumeMounts":[{"name":"con-creds-volume-name","readOnly":true,"mountPath":"/con-creds-mount-path"}]}]}]'
 spec:
   containers:
   - image: amazonlinux

--- a/pkg/handler/testdata/containercredentials/rawPodWithVolume.pod.yaml
+++ b/pkg/handler/testdata/containercredentials/rawPodWithVolume.pod.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: balajilovesoreos
+  uid: be8695c4-4ad0-4038-8786-c508853aa255
+  annotations:
+    testing.eks.amazonaws.com/skip: "false"
+    testing.eks.amazonaws.com/containercredentials/uri: "con-creds-uri"
+    testing.eks.amazonaws.com/containercredentials/audience: "con-creds-aud"
+    testing.eks.amazonaws.com/containercredentials/mountPath: "/con-creds-mount-path"
+    testing.eks.amazonaws.com/containercredentials/volumeName: "con-creds-volume-name"
+    testing.eks.amazonaws.com/containercredentials/tokenPath: "con-creds-token-path"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes/0","value":{"name":"con-creds-volume-name","projected":{"sources":[{"serviceAccountToken":{"audience":"con-creds-aud","expirationSeconds":86400,"path":"con-creds-token-path"}}]}}},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_CONTAINER_CREDENTIALS_FULL_URI","value":"con-creds-uri"},{"name":"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE","value":"/con-creds-mount-path/con-creds-token-path"}],"resources":{},"volumeMounts":[{"name":"con-creds-volume-name","readOnly":true,"mountPath":"/con-creds-mount-path"}]}]}]'
+spec:
+  containers:
+  - image: amazonlinux
+    name: balajilovesoreos
+  serviceAccountName: default
+  volumes:
+  - name: tokenPath

--- a/pkg/handler/testdata/containercredentials/rawPodWithoutVolumes.pod.yaml
+++ b/pkg/handler/testdata/containercredentials/rawPodWithoutVolumes.pod.yaml
@@ -6,7 +6,10 @@ metadata:
     testing.eks.amazonaws.com/skip: "false"
     testing.eks.amazonaws.com/containercredentials/uri: "con-creds-uri"
     testing.eks.amazonaws.com/containercredentials/audience: "con-creds-aud"
-    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"con-creds-aud","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_CONTAINER_CREDENTIALS_FULL_URI","value":"con-creds-uri"},{"name":"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]'
+    testing.eks.amazonaws.com/containercredentials/mountPath: "/con-creds-mount-path"
+    testing.eks.amazonaws.com/containercredentials/volumeName: "con-creds-volume-name"
+    testing.eks.amazonaws.com/containercredentials/tokenPath: "con-creds-token-path"
+    testing.eks.amazonaws.com/expectedPatch: '[{"op":"add","path":"/spec/volumes","value":[{"name":"con-creds-volume-name","projected":{"sources":[{"serviceAccountToken":{"audience":"con-creds-aud","expirationSeconds":86400,"path":"con-creds-token-path"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_CONTAINER_CREDENTIALS_FULL_URI","value":"con-creds-uri"},{"name":"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE","value":"/con-creds-mount-path/con-creds-token-path"}],"resources":{},"volumeMounts":[{"name":"con-creds-volume-name","readOnly":true,"mountPath":"/con-creds-mount-path"}]}]}]'
 spec:
   containers:
   - image: amazonlinux


### PR DESCRIPTION
*Description of changes:*
Update container credentials method to use a different mount path than the STS AssumeRoleWithWebIdentity method.  Prior this change, both methods will use the same mount path for the service account token.  However, this approach may cause confusions during migration from the AssumeRoleWithWebIdentity method to the Container credentials method.

Suppose user has the following AWS config file, which would signal SDK to use the AssumeRoleWithWebIdentity method.
```
[profile my_profile]
role_arn = arn:aws:iam::11111111:role/my-cool-role
web_identity_token_file = /var/run/secrets/eks.amazonaws.com/serviceaccount/token
```

When the container credentials method is enabled for the service account, the audience of the token in`/var/run/secrets/eks.amazonaws.com/serviceaccount/token` will be set to `pods.eks.amazonaws.com` rather than `sts.amazonaws.com`, and thus STS will return InvalidIdentityToken.

A separate mount path is helpful because
1. Removes the invalid call to STS
2. Make it explicit that the token is not sharable between the two methods.

*Testing:*
Mutated pod spec before this change
```
spec:
  containers:
  - args:
    - while true; do sleep 5; done
    command:
    - /bin/bash
    - -c
    - --
    env:
    - name: AWS_DEFAULT_REGION
      value: us-west-2
    - name: AWS_REGION
      value: us-west-2
    - name: AWS_CONTAINER_CREDENTIALS_FULL_URI
      value: http://169.254.170.23/v1/credentials
    - name: AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
      value: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
    image: public.ecr.aws/eks-distro-build-tooling/builder-base:latest
    imagePullPolicy: Always
    name: test-container
    ...
    volumeMounts:
    - mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
      name: aws-iam-token
      readOnly: true
  ...
  volumes:
  - name: aws-iam-token
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          audience: pods.eks.amazonaws.com
          expirationSeconds: 86400
          path: token
```

Mutated pod spec after this change
```
spec:
  containers:
  - args:
    - while true; do sleep 5; done
    command:
    - /bin/bash
    - -c
    - --
    env:
    - name: AWS_STS_REGIONAL_ENDPOINTS
      value: regional
    - name: AWS_DEFAULT_REGION
      value: us-west-2
    - name: AWS_REGION
      value: us-west-2
    - name: AWS_CONTAINER_CREDENTIALS_FULL_URI
      value: http://169.254.170.23/v1/credentials
    - name: AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
      value: **/var/run/secrets/pods.eks.amazonaws.com/serviceaccount/eks-pod-identity-token**
    image: public.ecr.aws/eks-distro-build-tooling/builder-base:latest
    imagePullPolicy: Always
    name: test-container
...
    volumeMounts:
    - mountPath: /var/run/secrets/pods.eks.amazonaws.com/serviceaccount <----- Change #1a
      name: eks-pod-identity-token <----- Change #1b
      readOnly: true
...
  volumes:
  - name: eks-pod-identity-token <----- Change #2
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          audience: pods.eks.amazonaws.com
          expirationSeconds: 86400
          path: eks-pod-identity-token <----- Change #3
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
