### PR TITLE
add metric to emit number of pods using sts web identity or container credentials

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -19,12 +19,13 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
-	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/containercredentials"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/containercredentials"
 
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/cache"
@@ -404,6 +405,9 @@ func (m *Modifier) buildPodPatchConfig(pod *corev1.Pod) *podPatchConfig {
 	if containerCredentialsPatchConfig != nil {
 		regionalSTS, tokenExpiration := m.Cache.GetCommonConfigurations(pod.Spec.ServiceAccountName, pod.Namespace)
 		tokenExpiration, containersToSkip := m.parsePodAnnotations(pod, tokenExpiration)
+
+		webhookPodCount.WithLabelValues("container_credentials").Inc()
+
 		return &podPatchConfig{
 			ContainersToSkip:                containersToSkip,
 			TokenExpiration:                 tokenExpiration,
@@ -418,6 +422,9 @@ func (m *Modifier) buildPodPatchConfig(pod *corev1.Pod) *podPatchConfig {
 	roleArn, audience, regionalSTS, tokenExpiration := m.Cache.Get(pod.Spec.ServiceAccountName, pod.Namespace)
 	if roleArn != "" {
 		tokenExpiration, containersToSkip := m.parsePodAnnotations(pod, tokenExpiration)
+
+		webhookPodCount.WithLabelValues("sts_web_identity").Inc()
+
 		return &podPatchConfig{
 			ContainersToSkip:                containersToSkip,
 			TokenExpiration:                 tokenExpiration,

--- a/pkg/handler/middleware.go
+++ b/pkg/handler/middleware.go
@@ -50,12 +50,19 @@ var (
 		},
 		[]string{"verb", "path"},
 	)
+	webhookPodCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pod_identity_webhook_pod_count",
+			Help: "Indicator to how many pods are using sts web identity or container credentials",
+		}, []string{"method"},
+	)
 )
 
 func register() {
 	prometheus.MustRegister(requestCounter)
 	prometheus.MustRegister(requestLatencies)
 	prometheus.MustRegister(requestLatenciesSummary)
+	prometheus.MustRegister(webhookPodCount)
 }
 
 func monitor(verb, path string, httpCode int, reqStart time.Time) {
@@ -100,13 +107,12 @@ func (w *statusLoggingResponseWriter) Write(data []byte) (int, error) {
 // InstrumentRoute is a middleware for adding the following metrics for each
 // route:
 //
-//     # Counter
-//     http_request_count{"verb", "path", "code}
-//     # Histogram
-//     http_request_latencies{"verb", "path"}
-//     # Summary
-//     http_request_duration_microseconds{"verb", "path", "code}
-//
+//	# Counter
+//	http_request_count{"verb", "path", "code}
+//	# Histogram
+//	http_request_latencies{"verb", "path"}
+//	# Summary
+//	http_request_duration_microseconds{"verb", "path", "code}
 func InstrumentRoute() Middleware {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds prometheus metric to emit number of pods using sts web identity or container credentials

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
