### PR TITLE
Don't push if there is no token or secret for dockerhub

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,14 @@ jobs:
         else
           TAG=$BRANCH
         fi
+        if [[ -z "${{ secrets.DOCKERHUB_USER }}" || -z "${{ secrets.DOCKERHUB_TOKEN }}" ]]; then
+          docker buildx build \
+                -t $REPO:$TAG \
+                --platform=linux/amd64,linux/arm64 \
+                --progress plain \
+                .
+          exit 0
+        fi
         docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
 
         docker buildx build \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Don't attempt to push to dockerhub if the token or secret variable isn't set. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
