### PR TITLE
gracefully terminate on SIGTERM

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509/pkix"
 	goflag "flag"
 	"fmt"
-	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/containercredentials"
 	"net/http"
 	"os"
 	"strings"
@@ -31,6 +30,7 @@ import (
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/cache"
 	cachedebug "github.com/aws/amazon-eks-pod-identity-webhook/pkg/cache/debug"
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/cert"
+	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/containercredentials"
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/handler"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -301,6 +301,8 @@ func main() {
 		Addr:    metricsAddr,
 		Handler: metricsMux,
 	}
+
+	handler.ShutdownFromContext(signalHandlerCtx, metricsServer, time.Duration(10)*time.Second)
 
 	go func() {
 		klog.Infof("Listening on %s", addr)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently the pod identity container wouldn't exit on SIGTERM because metricsServer is not handling the signal and would only exit on SIGKILL. Adding signal handling to the metric server also such that server is gracefully shutdown on SIGTERM

We can now see the graceful shutdown log after the change
```
I0221 21:37:52.906702      11 reflector.go:377] k8s.io/client-go/informers/factory.go:159: forcing resync
I0221 21:38:42.900211      11 file_watcher.go:91] context closed, stopping FileWatcher
I0221 21:38:42.900305      11 main.go:319] Graceflully closed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
