### PR TITLE
feat: cannonical label for skipping pod identity webhook

### DIFF
--- a/deploy/mutatingwebhook.yaml
+++ b/deploy/mutatingwebhook.yaml
@@ -15,7 +15,7 @@ webhooks:
       path: "/mutate"
   objectSelector:
     matchExpressions:
-      - key: eks.amazonaws.com/skip-identity-webhook
+      - key: eks.amazonaws.com/skip-pod-identity-webhook
         operator: "DoesNotExist"
         values: []
   rules:

--- a/deploy/mutatingwebhook.yaml
+++ b/deploy/mutatingwebhook.yaml
@@ -13,6 +13,11 @@ webhooks:
       name: pod-identity-webhook
       namespace: default
       path: "/mutate"
+  objectSelector:
+    matchExpressions:
+      - key: eks.amazonaws.com/skip-identity-webhook
+        operator: "DoesNotExist"
+        values: []
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]


### PR DESCRIPTION
Adds a condition to the mutating webhook, preventing pods from being processed with a particular label.

See: https://github.com/aws/amazon-eks-pod-identity-webhook/issues/215