### PR TITLE
Unify healthcheck endpoint port with application port

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Usage of amazon-eks-pod-identity-webhook:
       --log_file string                  If non-empty, use this log file
       --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
       --logtostderr                      log to standard error instead of files (default true)
-      --metrics-port int                 Port to listen on for metrics and healthz (http) (default 9999)
+      --metrics-port int                 Port to listen on for metrics (http) (default 9999)
       --namespace string                 (in-cluster) The namespace name this webhook, the TLS secret, and configmap resides in (default "eks")
       --port int                         Port to listen on (default 443)
       --service-name string              (in-cluster) The service name fronting this webhook (default "pod-identity-webhook")


### PR DESCRIPTION
*Description of changes:*

Unify healthz and service port for both the traffic to be served on the same port. Prevents issues where pod is considered healthy but not serving any requests.

*Testing:*

```
# start server via "make clean && make local-serve", then:

❯ curl -k -i https://localhost:8443/healthz
HTTP/2 200
content-type: text/plain; charset=utf-8
content-length: 2
date: Tue, 02 Jul 2024 00:17:44 GMT

ok
```

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
