### PR TITLE
cleanup old healthz endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -226,11 +226,6 @@ func main() {
 
 	metricsMux := http.NewServeMux()
 	metricsMux.Handle("/metrics", promhttp.Handler())
-	// TODO: Remove this extra healthz endpoint once we've migrated
-	// the health check service to the application port:
-	metricsMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "ok")
-	})
 
 	// Register debug endpoint only if flag is enabled
 	if *debug {


### PR DESCRIPTION


*Description of changes:*
This PR removes the deprecated /healthz endpoint as part of unifying the healthcheck with the application port.

This change is a followup from an earlier PR: https://github.com/aws/amazon-eks-pod-identity-webhook/pull/229


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
