### PR TITLE
Fix race condition between service account availability and webhook invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,37 +143,38 @@ When running a container with a non-root user, you need to give the container ac
 
 ```
 Usage of amazon-eks-pod-identity-webhook:
-      --add_dir_header                   If true, adds the file directory to the header
-      --alsologtostderr                  log to standard error as well as files
-      --annotation-prefix string         The Service Account annotation to look for (default "eks.amazonaws.com")
-      --aws-default-region string        If set, AWS_DEFAULT_REGION and AWS_REGION will be set to this value in mutated containers
-      --enable-debugging-handlers        Enable debugging handlers. Currently /debug/alpha/cache is supported
-      --in-cluster                       Use in-cluster authentication and certificate request API (default true)
-      --kube-api string                  (out-of-cluster) The url to the API server
-      --kubeconfig string                (out-of-cluster) Absolute path to the API server kubeconfig file
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --metrics-port int                 Port to listen on for metrics (http) (default 9999)
-      --namespace string                 (in-cluster) The namespace name this webhook, the TLS secret, and configmap resides in (default "eks")
-      --port int                         Port to listen on (default 443)
-      --service-name string              (in-cluster) The service name fronting this webhook (default "pod-identity-webhook")
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-      --sts-regional-endpoint false      Whether to inject the AWS_STS_REGIONAL_ENDPOINTS=regional env var in mutated pods. Defaults to false.
-      --tls-cert string                  (out-of-cluster) TLS certificate file path (default "/etc/webhook/certs/tls.crt")
-      --tls-key string                   (out-of-cluster) TLS key file path (default "/etc/webhook/certs/tls.key")
-      --tls-secret string                (in-cluster) The secret name for storing the TLS serving cert (default "pod-identity-webhook")
-      --token-audience string            The default audience for tokens. Can be overridden by annotation (default "sts.amazonaws.com")
-      --token-expiration int             The token expiration (default 86400)
-      --token-mount-path string          The path to mount tokens (default "/var/run/secrets/eks.amazonaws.com/serviceaccount")
-  -v, --v Level                          number for the log level verbosity
-      --version                          Display the version and exit
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
-      --watch-config-map                 Enables watching serviceaccounts that are configured through the pod-identity-webhook configmap instead of using annotations
+      --add_dir_header                       If true, adds the file directory to the header
+      --alsologtostderr                      log to standard error as well as files
+      --annotation-prefix string             The Service Account annotation to look for (default "eks.amazonaws.com")
+      --aws-default-region string            If set, AWS_DEFAULT_REGION and AWS_REGION will be set to this value in mutated containers
+      --enable-debugging-handlers            Enable debugging handlers. Currently /debug/alpha/cache is supported
+      --in-cluster                           Use in-cluster authentication and certificate request API (default true)
+      --kube-api string                      (out-of-cluster) The url to the API server
+      --kubeconfig string                    (out-of-cluster) Absolute path to the API server kubeconfig file
+      --log_backtrace_at traceLocation       when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                       If non-empty, write log files in this directory
+      --log_file string                      If non-empty, use this log file
+      --log_file_max_size uint               Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                          log to standard error instead of files (default true)
+      --metrics-port int                     Port to listen on for metrics (http) (default 9999)
+      --namespace string                     (in-cluster) The namespace name this webhook, the TLS secret, and configmap resides in (default "eks")
+      --port int                             Port to listen on (default 443)
+      --service-name string                  (in-cluster) The service name fronting this webhook (default "pod-identity-webhook")
+      --service-account-lookup-grace-period  The grace period for service account to be available in cache before not mutating a pod. Set to 0 to deactivate waiting. Carefully use higher values as it may have significant impact on Kubernetes' pod scheduling performance. (default 100ms)
+      --skip_headers                         If true, avoid header prefixes in the log messages
+      --skip_log_headers                     If true, avoid headers when opening log files
+      --stderrthreshold severity             logs at or above this threshold go to stderr (default 2)
+      --sts-regional-endpoint false          Whether to inject the AWS_STS_REGIONAL_ENDPOINTS=regional env var in mutated pods. Defaults to false.
+      --tls-cert string                      (out-of-cluster) TLS certificate file path (default "/etc/webhook/certs/tls.crt")
+      --tls-key string                       (out-of-cluster) TLS key file path (default "/etc/webhook/certs/tls.key")
+      --tls-secret string                    (in-cluster) The secret name for storing the TLS serving cert (default "pod-identity-webhook")
+      --token-audience string                The default audience for tokens. Can be overridden by annotation (default "sts.amazonaws.com")
+      --token-expiration int                 The token expiration (default 86400)
+      --token-mount-path string              The path to mount tokens (default "/var/run/secrets/eks.amazonaws.com/serviceaccount")
+  -v, --v Level                              number for the log level verbosity
+      --version                              Display the version and exit
+      --vmodule moduleSpec                   comma-separated list of pattern=N settings for file-filtered logging
+      --watch-config-map                     Enables watching serviceaccounts that are configured through the pod-identity-webhook configmap instead of using annotations
 ```
 
 ### AWS_DEFAULT_REGION Injection

--- a/main.go
+++ b/main.go
@@ -86,6 +86,8 @@ func main() {
 
 	debug := flag.Bool("enable-debugging-handlers", false, "Enable debugging handlers. Currently /debug/alpha/cache is supported")
 
+	saLookupGracePeriod := flag.Duration("service-account-lookup-grace-period", 100*time.Millisecond, "The grace period for service account to be available in cache before not mutating a pod. Defaults to 100ms. Set to 0 to deactivate waiting. Carefully use higher values as it may have significant impact on Kubernetes' pod scheduling performance.")
+
 	klog.InitFlags(goflag.CommandLine)
 	// Add klog CommandLine flags to pflag CommandLine
 	goflag.CommandLine.VisitAll(func(f *goflag.Flag) {
@@ -208,6 +210,7 @@ func main() {
 		handler.WithServiceAccountCache(saCache),
 		handler.WithContainerCredentialsConfig(containerCredentialsConfig),
 		handler.WithRegion(*region),
+		handler.WithSALookupGraceTime(*saLookupGracePeriod),
 	)
 
 	addr := fmt.Sprintf(":%d", *port)

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	debug := flag.Bool("enable-debugging-handlers", false, "Enable debugging handlers. Currently /debug/alpha/cache is supported")
 
-	saLookupGracePeriod := flag.Duration("service-account-lookup-grace-period", 100*time.Millisecond, "The grace period for service account to be available in cache before not mutating a pod. Defaults to 100ms. Set to 0 to deactivate waiting. Carefully use higher values as it may have significant impact on Kubernetes' pod scheduling performance.")
+	saLookupGracePeriod := flag.Duration("service-account-lookup-grace-period", 0, "The grace period for service account to be available in cache before not mutating a pod. Defaults to 0, what deactivates waiting. Carefully use values higher than a bunch of milliseconds as it may have significant impact on Kubernetes' pod scheduling performance.")
 
 	klog.InitFlags(goflag.CommandLine)
 	// Add klog CommandLine flags to pflag CommandLine

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -59,9 +59,8 @@ type Response struct {
 	Audience        string
 	UseRegionalSTS  bool
 	TokenExpiration int64
-	FoundInSACache  bool
-	FoundInCMCache  bool
-	Notifier        chan struct{}
+	FoundInCache    bool
+	Notifier        <-chan struct{}
 }
 
 type ServiceAccountCache interface {
@@ -123,7 +122,7 @@ func (c *serviceAccountCache) Get(req Request) Response {
 		var entry *Entry
 		entry, result.Notifier = c.getSA(req)
 		if entry != nil {
-			result.FoundInSACache = true
+			result.FoundInCache = true
 		}
 		if entry != nil && entry.RoleARN != "" {
 			result.RoleARN = entry.RoleARN
@@ -136,7 +135,7 @@ func (c *serviceAccountCache) Get(req Request) Response {
 	{
 		entry := c.getCM(req.Name, req.Namespace)
 		if entry != nil {
-			result.FoundInCMCache = true
+			result.FoundInCache = true
 			result.RoleARN = entry.RoleARN
 			result.Audience = entry.Audience
 			result.UseRegionalSTS = entry.UseRegionalSTS

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -49,10 +49,6 @@ type Request struct {
 func (r Request) CacheKey() string {
 	return r.Namespace + "/" + r.Name
 }
-func (r Request) WithNotification() Request {
-	r.RequestNotification = true
-	return r
-}
 
 type Response struct {
 	RoleARN         string

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -39,8 +39,7 @@ func TestSaCache(t *testing.T) {
 
 	resp := cache.Get(Request{Name: "default", Namespace: "default"})
 
-	assert.False(t, resp.FoundInCMCache, "Expected no cache entry to be found")
-	assert.False(t, resp.FoundInSACache, "Expected no cache entry to be found")
+	assert.False(t, resp.FoundInCache, "Expected no cache entry to be found")
 	if resp.RoleARN != "" || resp.Audience != "" {
 		t.Errorf("Expected role and aud to be empty, got %v", resp)
 	}
@@ -49,7 +48,7 @@ func TestSaCache(t *testing.T) {
 
 	resp = cache.Get(Request{Name: "default", Namespace: "default"})
 
-	assert.True(t, resp.FoundInSACache, "Expected cache entry to be found")
+	assert.True(t, resp.FoundInCache, "Expected cache entry to be found")
 	assert.Equal(t, roleArn, resp.RoleARN, "Expected role to be %s, got %s", roleArn, resp.RoleARN)
 	assert.Equal(t, "sts.amazonaws.com", resp.Audience, "Expected aud to be sts.amzonaws.com, got %s", resp.Audience)
 	assert.True(t, resp.UseRegionalSTS, "Expected regional STS to be true, got false")
@@ -77,8 +76,7 @@ func TestNotification(t *testing.T) {
 
 		// test that the requested SA is not in the cache
 		resp := cache.Get(reqWithoutNotification)
-		assert.False(t, resp.FoundInSACache, "Expected no cache entry to be found in SA cache")
-		assert.False(t, resp.FoundInCMCache, "Expected no cache entry to be found in CM cache")
+		assert.False(t, resp.FoundInCache, "Expected no cache entry to be found in cache")
 
 		// fetch with notification
 		resp = cache.Get(reqWithNotification)
@@ -100,7 +98,7 @@ func TestNotification(t *testing.T) {
 			// expected
 			// test that the requested SA is now in the cache
 			resp := cache.Get(reqWithoutNotification)
-			assert.True(t, resp.FoundInSACache, "Expected cache entry to be found in SA cache")
+			assert.True(t, resp.FoundInCache, "Expected cache entry to be found in cache")
 		case <-time.After(1 * time.Second):
 			t.Fatal("timeout waiting for notification")
 		}
@@ -115,8 +113,7 @@ func TestNotification(t *testing.T) {
 
 		// test that the requested SA is not in the cache
 		resp := cache.Get(reqWithoutNotification)
-		assert.False(t, resp.FoundInSACache, "Expected no cache entry to be found in SA cache")
-		assert.False(t, resp.FoundInCMCache, "Expected no cache entry to be found in CM cache")
+		assert.False(t, resp.FoundInCache, "Expected no cache entry to be found in cache")
 
 		// fetch with notification
 		resp = cache.Get(reqWithNotification)
@@ -126,17 +123,18 @@ func TestNotification(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
+
 				// wait for the notification
 				select {
 				case <-resp.Notifier:
 					// expected
 					// test that the requested SA is now in the cache
 					resp := cache.Get(reqWithoutNotification)
-					assert.True(t, resp.FoundInSACache, "Expected cache entry to be found in SA cache")
+					assert.True(t, resp.FoundInCache, "Expected cache entry to be found in cache")
 				case <-time.After(1 * time.Second):
 					t.Error("timeout waiting for notification")
 				}
-				wg.Done()
 			}()
 		}
 
@@ -261,7 +259,7 @@ func TestNonRegionalSTS(t *testing.T) {
 			}
 
 			resp := cache.Get(Request{Name: "default", Namespace: "default"})
-			assert.True(t, resp.FoundInSACache, "Expected cache entry to be found")
+			assert.True(t, resp.FoundInCache, "Expected cache entry to be found")
 			if resp.RoleARN != roleArn {
 				t.Errorf("got roleArn %v, expected %v", resp.RoleARN, roleArn)
 			}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -160,7 +160,6 @@ func TestNonRegionalSTS(t *testing.T) {
 				t.Fatalf("cache never called addSA: %v", err)
 			}
 
-			//gotRoleArn, gotAudience, useRegionalSTS, gotTokenExpiration, found := cache.Get("default", "default")
 			resp := cache.Get("default", "default")
 			assert.True(t, resp.FoundInSACache, "Expected cache entry to be found")
 			if resp.RoleARN != roleArn {

--- a/pkg/cache/debug/debug_test.go
+++ b/pkg/cache/debug/debug_test.go
@@ -83,7 +83,7 @@ func TestLister(t *testing.T) {
 				t.Errorf("Failed to read response: %v", err)
 				return
 			}
-			m := map[string]cache.CacheResponse{}
+			m := map[string]cache.Entry{}
 			err = json.Unmarshal(responseBytes, &m)
 			if err != nil {
 				t.Errorf("Failed to unmarshal: %v", err)

--- a/pkg/cache/fake.go
+++ b/pkg/cache/fake.go
@@ -44,14 +44,25 @@ var _ ServiceAccountCache = &FakeServiceAccountCache{}
 func (f *FakeServiceAccountCache) Start(chan struct{}) {}
 
 // Get gets a service account from the cache
-func (f *FakeServiceAccountCache) Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64) {
+func (f *FakeServiceAccountCache) Get(name, namespace string) (role, aud string, useRegionalSTS bool, tokenExpiration int64, found bool) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	resp, ok := f.cache[namespace+"/"+name]
 	if !ok {
-		return "", "", false, pkg.DefaultTokenExpiration
+		return "", "", false, pkg.DefaultTokenExpiration, false
 	}
-	return resp.RoleARN, resp.Audience, resp.UseRegionalSTS, resp.TokenExpiration
+	return resp.RoleARN, resp.Audience, resp.UseRegionalSTS, resp.TokenExpiration, true
+}
+
+// GetOrNotify gets a service account from the cache
+func (f *FakeServiceAccountCache) GetOrNotify(name, namespace string, handler chan any) (role, aud string, useRegionalSTS bool, tokenExpiration int64, found bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	resp, ok := f.cache[namespace+"/"+name]
+	if !ok {
+		return "", "", false, pkg.DefaultTokenExpiration, false
+	}
+	return resp.RoleARN, resp.Audience, resp.UseRegionalSTS, resp.TokenExpiration, true
 }
 
 func (f *FakeServiceAccountCache) GetCommonConfigurations(name, namespace string) (useRegionalSTS bool, tokenExpiration int64) {

--- a/pkg/cache/fake.go
+++ b/pkg/cache/fake.go
@@ -56,7 +56,7 @@ func (f *FakeServiceAccountCache) Get(req Request) Response {
 		Audience:        resp.Audience,
 		UseRegionalSTS:  resp.UseRegionalSTS,
 		TokenExpiration: resp.TokenExpiration,
-		FoundInSACache:  true,
+		FoundInCache:    true,
 	}
 }
 

--- a/pkg/cache/fake.go
+++ b/pkg/cache/fake.go
@@ -44,27 +44,10 @@ var _ ServiceAccountCache = &FakeServiceAccountCache{}
 func (f *FakeServiceAccountCache) Start(chan struct{}) {}
 
 // Get gets a service account from the cache
-func (f *FakeServiceAccountCache) Get(name, namespace string) Response {
+func (f *FakeServiceAccountCache) Get(req Request) Response {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
-	resp, ok := f.cache[namespace+"/"+name]
-	if !ok {
-		return Response{TokenExpiration: pkg.DefaultTokenExpiration}
-	}
-	return Response{
-		RoleARN:         resp.RoleARN,
-		Audience:        resp.Audience,
-		UseRegionalSTS:  resp.UseRegionalSTS,
-		TokenExpiration: resp.TokenExpiration,
-		FoundInSACache:  true,
-	}
-}
-
-// GetOrNotify gets a service account from the cache
-func (f *FakeServiceAccountCache) GetOrNotify(name, namespace string, handler chan struct{}) Response {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	resp, ok := f.cache[namespace+"/"+name]
+	resp, ok := f.cache[req.CacheKey()]
 	if !ok {
 		return Response{TokenExpiration: pkg.DefaultTokenExpiration}
 	}

--- a/pkg/cache/fake.go
+++ b/pkg/cache/fake.go
@@ -61,7 +61,7 @@ func (f *FakeServiceAccountCache) Get(name, namespace string) Response {
 }
 
 // GetOrNotify gets a service account from the cache
-func (f *FakeServiceAccountCache) GetOrNotify(name, namespace string, handler chan any) Response {
+func (f *FakeServiceAccountCache) GetOrNotify(name, namespace string, handler chan struct{}) Response {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	resp, ok := f.cache[namespace+"/"+name]

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -435,12 +435,12 @@ func (m *Modifier) buildPodPatchConfig(pod *corev1.Pod) *podPatchConfig {
 	// Use the STS WebIdentity method if set
 	request := cache.Request{Namespace: pod.Namespace, Name: pod.Spec.ServiceAccountName}
 	response := m.Cache.Get(request.WithNotification())
-	if !response.FoundInSACache && !response.FoundInCMCache && m.saLookupGraceTime > 0 {
+	if !response.FoundInCache && m.saLookupGraceTime > 0 {
 		klog.Warningf("Service account %s not found in the cache. Waiting up to %s to be notified", request.CacheKey(), m.saLookupGraceTime)
 		select {
 		case <-response.Notifier:
 			response = m.Cache.Get(request)
-			if !response.FoundInSACache && !response.FoundInCMCache {
+			if !response.FoundInCache {
 				klog.Warningf("Service account %s not found in the cache after being notified. Not mutating.", request.CacheKey())
 				return nil
 			}

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
+	"k8s.io/apimachinery/pkg/types"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -36,12 +37,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const uuid = "918ef1dc-928f-4525-99ef-988389f263c3"
+
 func TestMutatePod(t *testing.T) {
 	testServiceAccount := &v1.ServiceAccount{}
 	testServiceAccount.Name = "default"
 	testServiceAccount.Namespace = "default"
 	testServiceAccount.Annotations = map[string]string{
-		"eks.amazonaws.com/role-arn": "arn:aws:iam::111122223333:role/s3-reader",
+		"eks.amazonaws.com/role-arn":         "arn:aws:iam::111122223333:role/s3-reader",
+		"eks.amazonaws.com/token-expiration": "3600",
 	}
 
 	modifier := NewModifier(
@@ -63,6 +67,11 @@ func TestMutatePod(t *testing.T) {
 			&v1beta1.AdmissionReview{Request: nil},
 			&v1beta1.AdmissionResponse{Result: &metav1.Status{Message: "bad content"}},
 		},
+		{
+			"ValidRequest",
+			getValidReview(rawPodWithoutVolume),
+			getValidHandlerResponse(""),
+		},
 	}
 
 	for _, c := range cases {
@@ -73,6 +82,22 @@ func TestMutatePod(t *testing.T) {
 				got, _ := json.MarshalIndent(response, "", "  ")
 				want, _ := json.MarshalIndent(c.response, "", "  ")
 				t.Errorf("Unexpected response. Got \n%s\n wanted \n%s", string(got), string(want))
+			}
+			if len(response.Patch) > 0 {
+				patchOps := make([]patchOperation, 0)
+				if err := json.Unmarshal(response.Patch, &patchOps); err != nil {
+					t.Errorf("Failed to unmarshal patch: %v", err)
+				}
+				indentedPatchOps, _ := json.MarshalIndent(patchOps, "", "  ")
+				t.Logf("got patch operations: %s", string(indentedPatchOps))
+			}
+			if len(c.response.Patch) > 0 {
+				patchOps := make([]patchOperation, 0)
+				if err := json.Unmarshal(c.response.Patch, &patchOps); err != nil {
+					t.Errorf("Failed to unmarshal patch: %v", err)
+				}
+				indentedPatchOps, _ := json.MarshalIndent(patchOps, "", "  ")
+				t.Logf("wanted patch operations: %s", string(indentedPatchOps))
 			}
 		})
 	}
@@ -113,17 +138,19 @@ var rawPodWithoutVolume = []byte(`
 
 var validPatchIfNoVolumesPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":3600,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 
-var validHandlerResponse = &v1beta1.AdmissionResponse{
-	UID:       "918ef1dc-928f-4525-99ef-988389f263c3",
-	Allowed:   true,
-	Patch:     validPatchIfNoVolumesPresent,
-	PatchType: &jsonPatchType,
+func getValidHandlerResponse(uuid string) *v1beta1.AdmissionResponse {
+	return &v1beta1.AdmissionResponse{
+		UID:       types.UID(uuid),
+		Allowed:   true,
+		Patch:     validPatchIfNoVolumesPresent,
+		PatchType: &jsonPatchType,
+	}
 }
 
 func getValidReview(pod []byte) *v1beta1.AdmissionReview {
 	return &v1beta1.AdmissionReview{
 		Request: &v1beta1.AdmissionRequest{
-			UID: "918ef1dc-928f-4525-99ef-988389f263c3",
+			UID: uuid,
 			Kind: metav1.GroupVersionKind{
 				Version: "v1",
 				Kind:    "Pod",
@@ -216,7 +243,7 @@ func TestModifierHandler(t *testing.T) {
 			"ValidRequestSuccessWithoutVolumes",
 			serializeAdmissionReview(t, getValidReview(rawPodWithoutVolume)),
 			"application/json",
-			serializeAdmissionReview(t, &v1beta1.AdmissionReview{Response: validHandlerResponse}),
+			serializeAdmissionReview(t, &v1beta1.AdmissionReview{Response: getValidHandlerResponse(uuid)}),
 		},
 	}
 

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -83,22 +83,22 @@ func TestMutatePod(t *testing.T) {
 				want, _ := json.MarshalIndent(c.response, "", "  ")
 				t.Errorf("Unexpected response. Got \n%s\n wanted \n%s", string(got), string(want))
 			}
+			var expectedPatchOps, actualPatchOps []byte
 			if len(response.Patch) > 0 {
 				patchOps := make([]patchOperation, 0)
 				if err := json.Unmarshal(response.Patch, &patchOps); err != nil {
 					t.Errorf("Failed to unmarshal patch: %v", err)
 				}
-				indentedPatchOps, _ := json.MarshalIndent(patchOps, "", "  ")
-				t.Logf("got patch operations: %s", string(indentedPatchOps))
+				actualPatchOps, _ = json.MarshalIndent(patchOps, "", "  ")
 			}
 			if len(c.response.Patch) > 0 {
 				patchOps := make([]patchOperation, 0)
 				if err := json.Unmarshal(c.response.Patch, &patchOps); err != nil {
 					t.Errorf("Failed to unmarshal patch: %v", err)
 				}
-				indentedPatchOps, _ := json.MarshalIndent(patchOps, "", "  ")
-				t.Logf("wanted patch operations: %s", string(indentedPatchOps))
+				expectedPatchOps, _ = json.MarshalIndent(patchOps, "", "  ")
 			}
+			assert.Equal(t, string(expectedPatchOps), string(actualPatchOps))
 		})
 	}
 }


### PR DESCRIPTION
In #174 a race condition is mentioned, where the webhook tries to mutate a Pod having a service account reference which is not yet populated to the ServiceAccountCache. This results in the pod being not mutated. 

In our scenario this is a matter of a few milliseconds before the cache is properly populated. 

As an alternative to #178, this PR tries to fix this by waiting for a certain amount of time for proper ServiceAccountCache population and being notified upon population. Additionally, to wait only for SAs which aren't in the cache at all and not just missing a `RoleARN`, I had to restructure the return values of the `ServiceAccountCache` methods from multiple return values to structured data in order to transport the required information without adding additional two return values. 

<sub>Jan Roehrich <jan.roehrich@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/LEGAL_IMPRINT.md)</sub>