### PR TITLE
fetch SAs from apiserver

### DIFF
--- a/main.go
+++ b/main.go
@@ -181,6 +181,7 @@ func main() {
 		saInformer,
 		cmInformer,
 		composeRoleArnCache,
+		clientset.CoreV1(),
 	)
 	stop := make(chan struct{})
 	informerFactory.Start(stop)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -16,19 +16,23 @@
 package cache
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -80,8 +84,7 @@ type serviceAccountCache struct {
 	composeRoleArn         ComposeRoleArn
 	defaultTokenExpiration int64
 	webhookUsage           prometheus.Gauge
-	notificationHandlers   map[string]chan struct{}
-	handlerMu              sync.Mutex
+	notifications          *notifications
 }
 
 type ComposeRoleArn struct {
@@ -156,20 +159,13 @@ func (c *serviceAccountCache) GetCommonConfigurations(name, namespace string) (u
 	return false, pkg.DefaultTokenExpiration
 }
 
-func (c *serviceAccountCache) getSA(req Request) (*Entry, chan struct{}) {
+func (c *serviceAccountCache) getSA(req Request) (*Entry, <-chan struct{}) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	entry, ok := c.saCache[req.CacheKey()]
 	if !ok && req.RequestNotification {
 		klog.V(5).Infof("Service Account %s not found in cache, adding notification handler", req.CacheKey())
-		c.handlerMu.Lock()
-		defer c.handlerMu.Unlock()
-		notifier, found := c.notificationHandlers[req.CacheKey()]
-		if !found {
-			notifier = make(chan struct{})
-			c.notificationHandlers[req.CacheKey()] = notifier
-		}
-		return nil, notifier
+		return nil, c.notifications.create(req)
 	}
 	return entry, nil
 }
@@ -264,13 +260,7 @@ func (c *serviceAccountCache) setSA(name, namespace string, entry *Entry) {
 	klog.V(5).Infof("Adding SA %q to SA cache: %+v", key, entry)
 	c.saCache[key] = entry
 
-	c.handlerMu.Lock()
-	defer c.handlerMu.Unlock()
-	if handler, found := c.notificationHandlers[key]; found {
-		klog.V(5).Infof("Notifying handlers for %q", key)
-		close(handler)
-		delete(c.notificationHandlers, key)
-	}
+	c.notifications.broadcast(key)
 }
 
 func (c *serviceAccountCache) setCM(name, namespace string, entry *Entry) {
@@ -280,7 +270,15 @@ func (c *serviceAccountCache) setCM(name, namespace string, entry *Entry) {
 	c.cmCache[namespace+"/"+name] = entry
 }
 
-func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenExpiration int64, saInformer coreinformers.ServiceAccountInformer, cmInformer coreinformers.ConfigMapInformer, composeRoleArn ComposeRoleArn) ServiceAccountCache {
+func New(defaultAudience,
+	prefix string,
+	defaultRegionalSTS bool,
+	defaultTokenExpiration int64,
+	saInformer coreinformers.ServiceAccountInformer,
+	cmInformer coreinformers.ConfigMapInformer,
+	composeRoleArn ComposeRoleArn,
+	SAGetter corev1.ServiceAccountsGetter,
+) ServiceAccountCache {
 	hasSynced := func() bool {
 		if cmInformer != nil {
 			return saInformer.Informer().HasSynced() && cmInformer.Informer().HasSynced()
@@ -289,6 +287,8 @@ func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenEx
 		}
 	}
 
+	// Rate limit to 10 concurrent requests against the API server.
+	saFetchRequests := make(chan *Request, 10)
 	c := &serviceAccountCache{
 		saCache:                map[string]*Entry{},
 		cmCache:                map[string]*Entry{},
@@ -299,8 +299,19 @@ func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenEx
 		defaultTokenExpiration: defaultTokenExpiration,
 		hasSynced:              hasSynced,
 		webhookUsage:           webhookUsage,
-		notificationHandlers:   map[string]chan struct{}{},
+		notifications:          newNotifications(saFetchRequests),
 	}
+
+	go func() {
+		for req := range saFetchRequests {
+			sa, err := fetchFromAPI(SAGetter, req)
+			if err != nil {
+				klog.Errorf("fetching SA: %s, but got error from API: %v", req.CacheKey(), err)
+				continue
+			}
+			c.addSA(sa)
+		}
+	}()
 
 	saInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
@@ -349,6 +360,29 @@ func New(defaultAudience, prefix string, defaultRegionalSTS bool, defaultTokenEx
 		)
 	}
 	return c
+}
+
+func fetchFromAPI(getter corev1.ServiceAccountsGetter, req *Request) (*v1.ServiceAccount, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+	defer cancel()
+
+	klog.V(5).Infof("fetching SA: %s", req.CacheKey())
+	saList, err := getter.ServiceAccounts(req.Namespace).List(
+		ctx,
+		metav1.ListOptions{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the ServiceAccount
+	for _, sa := range saList.Items {
+		if sa.Name == req.Name {
+			return &sa, nil
+
+		}
+	}
+	return nil, fmt.Errorf("no SA found in namespace: %s", req.CacheKey())
 }
 
 func (c *serviceAccountCache) populateCacheFromCM(oldCM, newCM *v1.ConfigMap) error {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -28,12 +28,14 @@ import (
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
@@ -370,7 +372,19 @@ func fetchFromAPI(getter corev1.ServiceAccountsGetter, req *Request) (*v1.Servic
 
 	klog.V(5).Infof("fetching SA: %s", req.CacheKey())
 
-	return getter.ServiceAccounts(req.Namespace).Get(ctx, req.Name, metav1.GetOptions{})
+	var sa *v1.ServiceAccount
+	err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
+		return errors.IsServerTimeout(err)
+	}, func() error {
+		res, err := getter.ServiceAccounts(req.Namespace).Get(ctx, req.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		sa = res
+		return nil
+	})
+
+	return sa, err
 }
 
 func (c *serviceAccountCache) populateCacheFromCM(oldCM, newCM *v1.ConfigMap) error {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -157,7 +157,7 @@ func TestNotification(t *testing.T) {
 func TestFetchFromAPIServer(t *testing.T) {
 	testSA := &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "default",
+			Name:      "my-sa",
 			Namespace: "default",
 			Annotations: map[string]string{
 				"eks.amazonaws.com/role-arn":         "arn:aws:iam::111122223333:role/s3-reader",
@@ -196,7 +196,7 @@ func TestFetchFromAPIServer(t *testing.T) {
 		t.Fatalf("informer never called client: %v", err)
 	}
 
-	resp := cache.Get(Request{Name: "default", Namespace: "default", RequestNotification: true})
+	resp := cache.Get(Request{Name: "my-sa", Namespace: "default", RequestNotification: true})
 	assert.False(t, resp.FoundInCache, "Expected cache entry to not be found")
 
 	// wait for the notification while we fetch the SA from the API server:
@@ -204,7 +204,7 @@ func TestFetchFromAPIServer(t *testing.T) {
 	case <-resp.Notifier:
 		// expected
 		// test that the requested SA is now in the cache
-		resp := cache.Get(Request{Name: "default", Namespace: "default", RequestNotification: false})
+		resp := cache.Get(Request{Name: "my-sa", Namespace: "default", RequestNotification: false})
 		assert.True(t, resp.FoundInCache, "Expected cache entry to be found in cache")
 	case <-time.After(1 * time.Second):
 		t.Fatal("timeout waiting for notification")

--- a/pkg/cache/notifications.go
+++ b/pkg/cache/notifications.go
@@ -1,0 +1,60 @@
+package cache
+
+import (
+	"sync"
+
+	"k8s.io/klog/v2"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var notificationUsage = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "pod_identity_cache_notifications",
+		Help: "Counter of SA notifications",
+	},
+	[]string{"method"},
+)
+
+func init() {
+	prometheus.MustRegister(notificationUsage)
+}
+
+type notifications struct {
+	handlers      map[string]chan struct{}
+	mu            sync.Mutex
+	fetchRequests chan<- *Request
+}
+
+func newNotifications(saFetchRequests chan<- *Request) *notifications {
+	return &notifications{
+		handlers:      map[string]chan struct{}{},
+		fetchRequests: saFetchRequests,
+	}
+}
+
+func (n *notifications) create(req Request) <-chan struct{} {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	notificationUsage.WithLabelValues("used").Inc()
+	notifier, found := n.handlers[req.CacheKey()]
+	if !found {
+		notifier = make(chan struct{})
+		n.handlers[req.CacheKey()] = notifier
+		notificationUsage.WithLabelValues("created").Inc()
+		n.fetchRequests <- &req
+	}
+	return notifier
+}
+
+func (n *notifications) broadcast(key string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if handler, found := n.handlers[key]; found {
+		klog.V(5).Infof("Notifying handlers for %q", key)
+		notificationUsage.WithLabelValues("broadcast").Inc()
+		close(handler)
+		delete(n.handlers, key)
+	}
+}

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -433,9 +433,10 @@ func (m *Modifier) buildPodPatchConfig(pod *corev1.Pod) *podPatchConfig {
 	}
 
 	// Use the STS WebIdentity method if set
-	request := cache.Request{Namespace: pod.Namespace, Name: pod.Spec.ServiceAccountName, RequestNotification: true}
+	gracePeriodEnabled := m.saLookupGraceTime > 0
+	request := cache.Request{Namespace: pod.Namespace, Name: pod.Spec.ServiceAccountName, RequestNotification: gracePeriodEnabled}
 	response := m.Cache.Get(request)
-	if !response.FoundInCache && m.saLookupGraceTime > 0 {
+	if !response.FoundInCache && gracePeriodEnabled {
 		klog.Warningf("Service account %s not found in the cache. Waiting up to %s to be notified", request.CacheKey(), m.saLookupGraceTime)
 		select {
 		case <-response.Notifier:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -678,6 +678,7 @@ k8s.io/client-go/util/consistencydetector
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir
 k8s.io/client-go/util/keyutil
+k8s.io/client-go/util/retry
 k8s.io/client-go/util/watchlist
 k8s.io/client-go/util/workqueue
 # k8s.io/klog/v2 v2.130.1


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-eks-pod-identity-webhook/issues/174

*Description of changes:*
Enhances the implementation introduced in https://github.com/aws/amazon-eks-pod-identity-webhook/pull/236 so that we can fetch missing service accounts from the apiserver. Retains the existing guarantees that we won't fetch multiple service accounts concurrently, minimizing load on the apiserver.

This feature is still in shadow mode (off by default).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
