### PR TITLE
Support ConfigMap cache entries with wildcard namespace

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -131,6 +131,9 @@ func (c *serviceAccountCache) Get(req Request) Response {
 	}
 	{
 		entry := c.getCM(req.Name, req.Namespace)
+		if entry == nil {
+			entry = c.getCM(req.Name, "*")
+		}
 		if entry != nil {
 			result.FoundInCache = true
 			result.RoleARN = entry.RoleARN


### PR DESCRIPTION
*Issue #, if available:*

#237

*Description of changes:*

Support wildcards for namespace, meaning any ServiceAccount of a given name will be used regardless of what namespace it is in. Entries with a specific namespace defined takes precedence.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

