### PR TITLE
Switching to v1 admission review

### DIFF
--- a/deploy/mutatingwebhook.yaml
+++ b/deploy/mutatingwebhook.yaml
@@ -24,4 +24,4 @@ webhooks:
     apiVersions: ["v1"]
     resources: ["pods"]
   sideEffects: None
-  admissionReviewVersions: ["v1beta1"]
+  admissionReviewVersions: ["v1"]


### PR DESCRIPTION
This PR bumps the admission review related k8s types from v1beta1 to v1 as k/k has promoted the v1 API to GA on 1.30:

> https://github.com/kubernetes/kubernetes/pull/123405