### PR TITLE
Updating actions to publish to ecr public

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,8 +6,20 @@ jobs:
     # this is to prevent the job to run at forked projects
     if: github.repository == 'aws/amazon-eks-pod-identity-webhook'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v3
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::719983614556:role/github-actions-amazon-eks-pod-identity-webhook
+        aws-region: us-east-1
+    - name: Login to Amazon ECR Public
+      id: login-ecr-public
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        registry-type: public
     - name: Setup Go Version
       run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - name: Set up Docker Buildx
@@ -16,26 +28,17 @@ jobs:
       with:
         buildx-version: latest
         qemu-version: latest
+    
     - name: Build container and push to Dockerhub registry
       run: |
         BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
         SHORT_SHA=$(echo $GITHUB_SHA | cut -c -7)
-        REPO=amazon/amazon-eks-pod-identity-webhook
+        REPO=public.ecr.aws/c5c3y3r8/amazon-eks-pod-identity-webhook
         if [ "$BRANCH" = "master" ]; then
           TAG=$SHORT_SHA
         else
           TAG=$BRANCH
         fi
-        if [[ -z "${{ secrets.DOCKERHUB_USER }}" || -z "${{ secrets.DOCKERHUB_TOKEN }}" ]]; then
-          docker buildx build \
-                -t $REPO:$TAG \
-                --build-arg golang_image=public.ecr.aws/eks-distro-build-tooling/golang:${{ env.GO_VERSION }}-gcc \
-                --platform=linux/amd64,linux/arm64 \
-                --progress plain \
-                .
-          exit 0
-        fi
-        docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
 
         docker buildx build \
               -t $REPO:$TAG \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::719983614556:role/github-actions-amazon-eks-pod-identity-webhook
+        role-to-assume: arn:aws:iam::314666526026:role/github-actions-amazon-eks-pod-identity-webhook
         aws-region: us-east-1
     - name: Login to Amazon ECR Public
       id: login-ecr-public
@@ -27,13 +27,12 @@ jobs:
       uses: crazy-max/ghaction-docker-buildx@v3
       with:
         buildx-version: latest
-        qemu-version: latest
-    
+        qemu-version: latest  
     - name: Build container and push to Dockerhub registry
       run: |
         BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
         SHORT_SHA=$(echo $GITHUB_SHA | cut -c -7)
-        REPO=public.ecr.aws/c5c3y3r8/amazon-eks-pod-identity-webhook
+        REPO=public.ecr.aws/eks/amazon-eks-pod-identity-webhook
         if [ "$BRANCH" = "master" ]; then
           TAG=$SHORT_SHA
         else

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ metadata:
 
 ## Container Images
 
-Container images for amazon-eks-pod-identity-webhook can be found on [Docker Hub](https://hub.docker.com/r/amazon/amazon-eks-pod-identity-webhook).
+Container images for amazon-eks-pod-identity-webhook can be found on [ECR](https://gallery.ecr.aws/eks/amazon-eks-pod-identity-webhook).
 
 ## Installation
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-eks-pod-identity-webhook/issues/256

*Description of changes:*
This change updates the actions pipeline to publish to the ECR public. Currently the repo alias is still being reviewed but we can start publishing to ECR before the custom alias is applied. Images can be viewed [here.](https://gallery.ecr.aws/eks/amazon-eks-pod-identity-webhook)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
