### PR TITLE
Removed namespace as MutatingWebhookConfiguration is not namespaced

### DIFF
--- a/deploy/mutatingwebhook.yaml
+++ b/deploy/mutatingwebhook.yaml
@@ -2,7 +2,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: pod-identity-webhook
-  namespace: default
   annotations:
     cert-manager.io/inject-ca-from: default/pod-identity-webhook
 webhooks:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removed the namespace field because `MutatingWebhookConfiguration` is a cluster-scoped resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
