### PR TITLE
Implement graceful shutdown

### DIFF
--- a/pkg/handler/shutdown_test.go
+++ b/pkg/handler/shutdown_test.go
@@ -50,14 +50,9 @@ func TestShutdownFromContext_SuccessfulGracefulShutdown(t *testing.T) {
 		t.Fatal("Shutdown did not complete within expected time")
 	}
 
-	// Check that no error occurred (graceful shutdown succeeded)
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Errorf("Expected no error for graceful shutdown, got: %v", err)
-		}
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("Did not receive error status within expected time")
+	// Check that no error occurred (graceful shutdown succeeded).
+	if err := <-errCh; err != nil {
+		t.Errorf("Expected no error for graceful shutdown, got: %v", err)
 	}
 }
 
@@ -100,14 +95,9 @@ func TestShutdownFromContext_GracefulShutdownTimeout(t *testing.T) {
 	}
 
 	// Check that we got an error (timeout should always cause an error)
-	select {
-	case err := <-errCh:
-		if err == nil {
-			t.Error("Expected error for graceful shutdown timeout, but got nil")
-		} else {
-			t.Logf("Received expected error with very short timeout: %v", err)
-		}
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("Did not receive error status within expected time")
+	if err := <-errCh; err == nil {
+		t.Error("Expected error for graceful shutdown timeout, but got nil")
+	} else {
+		t.Logf("Received expected error with very short timeout: %v", err)
 	}
 }

--- a/pkg/handler/shutdown_test.go
+++ b/pkg/handler/shutdown_test.go
@@ -1,0 +1,113 @@
+/*
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  A copy of the License is located at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  or in the "license" file accompanying this file. This file is distributed
+  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing
+  permissions and limitations under the License.
+*/
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestShutdownFromContext_SuccessfulGracefulShutdown(t *testing.T) {
+	// Create a test server
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Create a context that we can cancel
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Call ShutdownFromContext
+	doneCh, errCh := ShutdownFromContext(ctx, server.Config, 2*time.Second)
+
+	// Start the server
+	server.Start()
+	defer server.Close()
+
+	// Cancel the context to trigger shutdown
+	cancel()
+
+	// Wait for shutdown to complete
+	select {
+	case <-doneCh:
+		// Shutdown completed
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown did not complete within expected time")
+	}
+
+	// Check that no error occurred (graceful shutdown succeeded)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("Expected no error for graceful shutdown, got: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Did not receive error status within expected time")
+	}
+}
+
+func TestShutdownFromContext_GracefulShutdownTimeout(t *testing.T) {
+	// Create a test server with a slow handler that will delay shutdown
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate a slow handler that takes time to complete
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Start the server
+	testServer.Start()
+	defer testServer.Close()
+
+	// Start a request to the slow handler to create an active connection during shutdown
+	go func() {
+		client := &http.Client{}
+		client.Get(testServer.URL)
+	}()
+
+	// Give the request time to start
+	time.Sleep(10 * time.Millisecond)
+
+	// Create a context that we can cancel
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Call ShutdownFromContext with a very short timeout to force timeout
+	doneCh, errCh := ShutdownFromContext(ctx, testServer.Config, 1*time.Nanosecond)
+
+	// Cancel the context to trigger shutdown
+	cancel()
+
+	// Wait for shutdown to complete
+	select {
+	case <-doneCh:
+		// Shutdown completed
+	case <-time.After(1 * time.Second):
+		t.Fatal("Shutdown did not complete within expected time")
+	}
+
+	// Check that we got an error (timeout should always cause an error)
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Error("Expected error for graceful shutdown timeout, but got nil")
+		} else {
+			t.Logf("Received expected error with very short timeout: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Did not receive error status within expected time")
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/aws/amazon-eks-pod-identity-webhook/issues/271, a race condition during shutdown that can lead to in-flight requests to the webhook being terminated abruptly on pod shutdown.

### Description of changes

Previously, the metrics server was running on the main routine, while the webhook server was handled in a separate goroutine. This setup has been updated so that both the metrics server and the webhook server now run in dedicated goroutines, improving separation of concerns and shutdown coordination.

The `ShutdownFromContext()` function has been modified to return two channels:
- One signals when server shutdown is complete.
- The other reports any errors encountered during shutdown.

The main routine now listens on these channels to ensure that shutdown proceeds gracefully and completes before exiting.

The PR also adds unit tests for `ShutdownFromContext()`.

### Licensing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.