### PR TITLE
bump go to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-eks-pod-identity-webhook
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump go version address CVE.
On top of https://github.com/aws/amazon-eks-pod-identity-webhook/pull/294/changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
