### PR TITLE
fix: echo request TypeMeta in admission response to comply with Kubernetes webhook spec

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -32,23 +32,9 @@ import (
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/cache"
 	"k8s.io/api/admission/v1beta1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/klog/v2"
-)
-
-func init() {
-	_ = corev1.AddToScheme(runtimeScheme)
-	_ = admissionregistrationv1beta1.AddToScheme(runtimeScheme)
-}
-
-var (
-	runtimeScheme = runtime.NewScheme()
-	codecs        = serializer.NewCodecFactory(runtimeScheme)
-	deserializer  = codecs.UniversalDeserializer()
 )
 
 // ModifierOpt is an option type for setting up a Modifier
@@ -601,7 +587,7 @@ func (m *Modifier) Handle(w http.ResponseWriter, r *http.Request) {
 
 	var admissionResponse *v1beta1.AdmissionResponse
 	ar := v1beta1.AdmissionReview{}
-	if _, _, err := deserializer.Decode(body, nil, &ar); err != nil {
+	if err := json.Unmarshal(body, &ar); err != nil {
 		klog.Errorf("Can't decode body: %v", err)
 		admissionResponse = &v1beta1.AdmissionResponse{
 			Result: &metav1.Status{
@@ -613,6 +599,7 @@ func (m *Modifier) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	admissionReview := v1beta1.AdmissionReview{}
+	admissionReview.TypeMeta = ar.TypeMeta
 	if admissionResponse != nil {
 		admissionReview.Response = admissionResponse
 		if ar.Request != nil {

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -177,6 +177,15 @@ func getValidReview(pod []byte) *v1beta1.AdmissionReview {
 	}
 }
 
+func getValidReviewWithTypeMeta(pod []byte, apiVersion, kind string) *v1beta1.AdmissionReview {
+	review := getValidReview(pod)
+	review.TypeMeta = metav1.TypeMeta{
+		APIVersion: apiVersion,
+		Kind:       kind,
+	}
+	return review
+}
+
 func serializeAdmissionReview(t *testing.T, want *v1beta1.AdmissionReview) []byte {
 	wantedBytes, err := json.Marshal(want)
 	if err != nil {
@@ -228,7 +237,7 @@ func TestModifierHandler(t *testing.T) {
 			nil,
 			"application/json",
 			serializeAdmissionReview(t, &v1beta1.AdmissionReview{
-				Response: &v1beta1.AdmissionResponse{Result: &metav1.Status{Message: "bad content"}},
+				Response: &v1beta1.AdmissionResponse{Result: &metav1.Status{Message: "unexpected end of JSON input"}},
 			}),
 		},
 		{
@@ -249,7 +258,7 @@ func TestModifierHandler(t *testing.T) {
 			"InvalidJSON",
 			[]byte(`{"request": {"object": "\"metadata\":{\"name\":\"fake\""}`),
 			"application/json",
-			[]byte(`{"response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"couldn't get version/kind; json parse error: unexpected end of JSON input"}}}`),
+			[]byte(`{"response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"unexpected end of JSON input"}}}`),
 		},
 		{
 			"InvalidPodBytes",
@@ -262,6 +271,22 @@ func TestModifierHandler(t *testing.T) {
 			serializeAdmissionReview(t, getValidReview(rawPodWithoutVolume)),
 			"application/json",
 			serializeAdmissionReview(t, &v1beta1.AdmissionReview{Response: getValidHandlerResponse(uuid)}),
+		},
+		{
+			// Regression test: when a v1 AdmissionReview is sent (K3s / k8s >= 1.16),
+			// the response must echo back the same apiVersion and kind so the API
+			// server can decode it. Previously the handler returned an empty TypeMeta,
+			// causing "got /, Kind=" errors on non-EKS clusters.
+			"ValidRequestV1TypeMetaEchoed",
+			serializeAdmissionReview(t, getValidReviewWithTypeMeta(rawPodWithoutVolume, "admission.k8s.io/v1", "AdmissionReview")),
+			"application/json",
+			serializeAdmissionReview(t, &v1beta1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "admission.k8s.io/v1",
+					Kind:       "AdmissionReview",
+				},
+				Response: getValidHandlerResponse(uuid),
+			}),
 		},
 	}
 


### PR DESCRIPTION
## Problem

The Kubernetes webhook specification requires that a webhook response include the same `apiVersion` and `kind` as the request. The handler was building the response `AdmissionReview` struct without copying TypeMeta from the request, so every response serialized as:

```json
{"response": {"uid": "...", "allowed": true, "patch": "..."}}
```

API servers enforce this strictly:

```
received invalid webhook response: expected webhook response of admission.k8s.io/v1,
Kind=AdmissionReview, got /, Kind=
```

This is a known issue — see #225, where an EKS cluster upgraded to Kubernetes 1.27 with `admissionReviewVersions: v1` began rejecting webhook responses and injection stopped working. The only workaround was to downgrade to `v1beta1`. The root cause is the same: when the API server negotiates v1, the response comes back with an empty `apiVersion`/`kind` and is rejected.

A related issue: `deserializer.Decode` used a codec scheme that registered only `corev1` and `admissionregistrationv1beta1` — not the admission API types. Any cluster sending `admission.k8s.io/v1` requests would fail to decode before mutation ran.

## Fix

**`pkg/handler/handler.go`**

1. Copy `ar.TypeMeta` into the response struct before marshalling — the response echoes back whatever `apiVersion`/`kind` the request carried, as the spec requires.
2. Replace `deserializer.Decode` with `json.Unmarshal`. `json.Unmarshal` decodes both `v1` and `v1beta1` payloads correctly without a registered scheme. The old codec scheme did not include the admission API types, so it was incapable of decoding v1 requests.
3. Remove the now-unused `runtimeScheme`, `codecs`, `deserializer` package vars and `init()`.

**`pkg/handler/handler_test.go`**

1. Update two test cases for the new `json.Unmarshal` error strings.
2. Add regression test `ValidRequestV1TypeMetaEchoed`: sends an `AdmissionReview` with `apiVersion: admission.k8s.io/v1` and asserts the response echoes it back.

## Testing

```
go test ./pkg/handler/...
```

All tests pass.

## Related

- #225 — EKS 1.27 upgrade breaks injection when `admissionReviewVersions: v1`; workaround was to force `v1beta1`