### PR TITLE
fix: migrate admission API from v1beta1 to v1 and echo TypeMeta in response

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg"
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/cache"
-	"k8s.io/api/admission/v1beta1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,7 +42,7 @@ import (
 
 func init() {
 	_ = corev1.AddToScheme(runtimeScheme)
-	_ = admissionregistrationv1beta1.AddToScheme(runtimeScheme)
+	_ = admissionregistrationv1.AddToScheme(runtimeScheme)
 }
 
 var (
@@ -517,8 +517,8 @@ func (m *Modifier) addJitterToDefaultToken(tokenExpiration int64) int64 {
 }
 
 // MutatePod takes a AdmissionReview, mutates the pod, and returns an AdmissionResponse
-func (m *Modifier) MutatePod(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
-	badRequest := &v1beta1.AdmissionResponse{
+func (m *Modifier) MutatePod(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	badRequest := &admissionv1.AdmissionResponse{
 		Result: &metav1.Status{
 			Message: "bad content",
 		},
@@ -535,7 +535,7 @@ func (m *Modifier) MutatePod(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResp
 	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
 		klog.Errorf("Could not unmarshal raw object: %v", err)
 		klog.Errorf("Object: %v", string(req.Object.Raw))
-		return &v1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Result: &metav1.Status{
 				Message: err.Error(),
 			},
@@ -548,7 +548,7 @@ func (m *Modifier) MutatePod(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResp
 	if patchConfig == nil {
 		klog.V(4).Infof("Pod was not mutated. Reason: "+
 			"Service account did not have the right annotations or was not found in the cache. %s", logContext(pod.Name, pod.GenerateName, pod.Spec.ServiceAccountName, pod.Namespace))
-		return &v1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -557,7 +557,7 @@ func (m *Modifier) MutatePod(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResp
 	patchBytes, err := json.Marshal(patch)
 	if err != nil {
 		klog.Errorf("Error marshaling pod update: %v", err.Error())
-		return &v1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Result: &metav1.Status{
 				Message: err.Error(),
 			},
@@ -572,11 +572,11 @@ func (m *Modifier) MutatePod(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResp
 			"Required volume mounts and env variables were already present. %s", logContext(pod.Name, pod.GenerateName, pod.Spec.ServiceAccountName, pod.Namespace))
 	}
 
-	return &v1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 		Patch:   patchBytes,
-		PatchType: func() *v1beta1.PatchType {
-			pt := v1beta1.PatchTypeJSONPatch
+		PatchType: func() *admissionv1.PatchType {
+			pt := admissionv1.PatchTypeJSONPatch
 			return &pt
 		}(),
 	}
@@ -599,11 +599,11 @@ func (m *Modifier) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var admissionResponse *v1beta1.AdmissionResponse
-	ar := v1beta1.AdmissionReview{}
+	var admissionResponse *admissionv1.AdmissionResponse
+	ar := admissionv1.AdmissionReview{}
 	if _, _, err := deserializer.Decode(body, nil, &ar); err != nil {
 		klog.Errorf("Can't decode body: %v", err)
-		admissionResponse = &v1beta1.AdmissionResponse{
+		admissionResponse = &admissionv1.AdmissionResponse{
 			Result: &metav1.Status{
 				Message: err.Error(),
 			},
@@ -612,7 +612,8 @@ func (m *Modifier) Handle(w http.ResponseWriter, r *http.Request) {
 		admissionResponse = m.MutatePod(&ar)
 	}
 
-	admissionReview := v1beta1.AdmissionReview{}
+	admissionReview := admissionv1.AdmissionReview{}
+	admissionReview.TypeMeta = ar.TypeMeta
 	if admissionResponse != nil {
 		admissionReview.Response = admissionResponse
 		if ar.Request != nil {

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -32,7 +32,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-eks-pod-identity-webhook/pkg/cache"
-	"k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -59,18 +59,18 @@ func TestMutatePod(t *testing.T) {
 
 	cases := []struct {
 		caseName string
-		input    *v1beta1.AdmissionReview
-		response *v1beta1.AdmissionResponse
+		input    *admissionv1.AdmissionReview
+		response *admissionv1.AdmissionResponse
 	}{
 		{
 			"nilBody",
 			nil,
-			&v1beta1.AdmissionResponse{Result: &metav1.Status{Message: "bad content"}},
+			&admissionv1.AdmissionResponse{Result: &metav1.Status{Message: "bad content"}},
 		},
 		{
 			"NoRequest",
-			&v1beta1.AdmissionReview{Request: nil},
-			&v1beta1.AdmissionResponse{Result: &metav1.Status{Message: "bad content"}},
+			&admissionv1.AdmissionReview{Request: nil},
+			&admissionv1.AdmissionResponse{Result: &metav1.Status{Message: "bad content"}},
 		},
 		{
 			"ValidRequest",
@@ -120,7 +120,7 @@ func TestMutatePod_MutationNotNeeded(t *testing.T) {
 	assert.Nil(t, response.Patch)
 }
 
-var jsonPatchType = v1beta1.PatchType("JSONPatch")
+var jsonPatchType = admissionv1.PatchType("JSONPatch")
 
 var rawPodWithoutVolume = []byte(`
 {
@@ -144,8 +144,8 @@ var rawPodWithoutVolume = []byte(`
 
 var validPatchIfNoVolumesPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":3600,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 
-func getValidHandlerResponse(uuid string) *v1beta1.AdmissionResponse {
-	return &v1beta1.AdmissionResponse{
+func getValidHandlerResponse(uuid string) *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{
 		UID:       types.UID(uuid),
 		Allowed:   true,
 		Patch:     validPatchIfNoVolumesPresent,
@@ -153,9 +153,18 @@ func getValidHandlerResponse(uuid string) *v1beta1.AdmissionResponse {
 	}
 }
 
-func getValidReview(pod []byte) *v1beta1.AdmissionReview {
-	return &v1beta1.AdmissionReview{
-		Request: &v1beta1.AdmissionRequest{
+func getValidReviewWithTypeMeta(pod []byte, apiVersion, kind string) *admissionv1.AdmissionReview {
+	review := getValidReview(pod)
+	review.TypeMeta = metav1.TypeMeta{
+		APIVersion: apiVersion,
+		Kind:       kind,
+	}
+	return review
+}
+
+func getValidReview(pod []byte) *admissionv1.AdmissionReview {
+	return &admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
 			UID: uuid,
 			Kind: metav1.GroupVersionKind{
 				Version: "v1",
@@ -177,7 +186,7 @@ func getValidReview(pod []byte) *v1beta1.AdmissionReview {
 	}
 }
 
-func serializeAdmissionReview(t *testing.T, want *v1beta1.AdmissionReview) []byte {
+func serializeAdmissionReview(t *testing.T, want *admissionv1.AdmissionReview) []byte {
 	wantedBytes, err := json.Marshal(want)
 	if err != nil {
 		t.Errorf("Failed to marshal desired response: %v", err)
@@ -227,21 +236,21 @@ func TestModifierHandler(t *testing.T) {
 			"nilBody",
 			nil,
 			"application/json",
-			serializeAdmissionReview(t, &v1beta1.AdmissionReview{
-				Response: &v1beta1.AdmissionResponse{Result: &metav1.Status{Message: "bad content"}},
+			serializeAdmissionReview(t, &admissionv1.AdmissionReview{
+				Response: &admissionv1.AdmissionResponse{Result: &metav1.Status{Message: "bad content"}},
 			}),
 		},
 		{
 			"NoRequest",
-			serializeAdmissionReview(t, &v1beta1.AdmissionReview{Request: nil}),
+			serializeAdmissionReview(t, &admissionv1.AdmissionReview{Request: nil}),
 			"application/json",
-			serializeAdmissionReview(t, &v1beta1.AdmissionReview{
-				Response: &v1beta1.AdmissionResponse{Result: &metav1.Status{Message: "bad content"}},
+			serializeAdmissionReview(t, &admissionv1.AdmissionReview{
+				Response: &admissionv1.AdmissionResponse{Result: &metav1.Status{Message: "bad content"}},
 			}),
 		},
 		{
 			"BadContentType",
-			serializeAdmissionReview(t, &v1beta1.AdmissionReview{Request: nil}),
+			serializeAdmissionReview(t, &admissionv1.AdmissionReview{Request: nil}),
 			"application/xml",
 			[]byte("Invalid Content-Type, expected `application/json`\n"),
 		},
@@ -261,7 +270,24 @@ func TestModifierHandler(t *testing.T) {
 			"ValidRequestSuccessWithoutVolumes",
 			serializeAdmissionReview(t, getValidReview(rawPodWithoutVolume)),
 			"application/json",
-			serializeAdmissionReview(t, &v1beta1.AdmissionReview{Response: getValidHandlerResponse(uuid)}),
+			serializeAdmissionReview(t, &admissionv1.AdmissionReview{Response: getValidHandlerResponse(uuid)}),
+		},
+		{
+			// Regression test: when a v1 AdmissionReview is sent (k3s, kOps,
+			// vanilla k8s >= 1.16), the response must echo back the same
+			// apiVersion and kind so the API server can decode it.
+			// Previously the handler returned an empty TypeMeta, causing
+			// "got /, Kind=" errors on non-EKS clusters.
+			"ValidRequestV1TypeMetaEchoed",
+			serializeAdmissionReview(t, getValidReviewWithTypeMeta(rawPodWithoutVolume, "admission.k8s.io/v1", "AdmissionReview")),
+			"application/json",
+			serializeAdmissionReview(t, &admissionv1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "admission.k8s.io/v1",
+					Kind:       "AdmissionReview",
+				},
+				Response: getValidHandlerResponse(uuid),
+			}),
 		},
 	}
 


### PR DESCRIPTION
### Problem

The webhook handler uses admission/v1beta1 types and returns an AdmissionReview response without TypeMeta. On non-EKS clusters, the API server rejects the response:

```
received invalid webhook response: expected webhook response of
admission.k8s.io/v1, Kind=AdmissionReview, got /, Kind=
```

EKS patches its API server to tolerate the missing TypeMeta, which is why this has gone unnoticed upstream. All self-managed deployments (k3s, kOps, kubeadm, etc.) are affected.

This has been reported multiple times: #225, #205, #132. A similar fix was proposed in #304 but never merged.

### Fix

Migrate handler and tests from admission/v1beta1 to admission/v1
Echo the request TypeMeta into the response (handles both API versions transparently, following the approach from #304)
Add regression test verifying TypeMeta is properly echoed

###Tested on

k3s v1.31 — pods are correctly mutated after the fix.